### PR TITLE
fix: juju hardening link that (must have) moved

### DIFF
--- a/docs/how-to-guides/security/harden-your-deployment.md
+++ b/docs/how-to-guides/security/harden-your-deployment.md
@@ -68,4 +68,4 @@ Ubuntu LTS releases with Ubuntu Pro can take advantage of the [Ubuntu Security G
 
 ## Harden Juju
 
-If you used Juju to deploy Landscape, you can follow [Juju's hardening guide](https://juju.is/docs/juju/harden-your-deployment) to harden the Juju aspects of your deployment.
+If you used Juju to deploy Landscape, you can follow [Juju's hardening guide](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/#harden-your-deployment) to harden the Juju aspects of your deployment.


### PR DESCRIPTION
Doesn't look like https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/harden-your-deployment/ exists anymore