### PR TITLE
docs: create activities and remote script execution explanation doc

### DIFF
--- a/docs/explanation/features/activities.md
+++ b/docs/explanation/features/activities.md
@@ -1,12 +1,55 @@
 (explanation-activities)=
-
 # Activities
 
-This document describes activities and outlines the services and steps involved for Landscape to complete activities.
+Landscape tracks the progress of various tasks using activities. There are two types of activities: client activities and server activities. This document will explain how each type of activity is tracked and their possible states.
 
-## Overview of activities
+## Client activities
 
-# steps for how it communicates with client
+Client activities are tasks that execute on Landscape Client. Examples include {ref}`remote script execution <explanation-remote-script-execution>`. They are processed by the `message-system` when an instance exchanges messages with Landscape Server.
 
-  message sent to client
-  client sends back operation status
+### Client activity states
+
+Activities can start in the `Queued`, `Scheduled`, `Waiting`, or `Blocked` states.
+
+- `Queued`: Activity will run the next time the client exchanges messages. Can transition to `In Progress`, `Canceled`, or `Blocked`.
+- `Scheduled`: Activity will run at a future time. Can transition to `In Progress` or `Canceled`.
+- `Waiting`: Activity will not run until another activity completes or reaches a progress threshold. Can transition to `Queued`, `In Progress`, or `Canceled`.
+- `Blocked`: Activity is paused (often awaiting admin approval). Can transition to `Queued`, `Canceled`, or `Waiting`.
+- `In Progress`: Activity has been sent to the client. Can transition to `Failed`, `Succeeded`, or `Canceled`.
+- `Failed`: Landscape Client reported an error while executing. This is a final state.
+- `Canceled`: Activity was stopped before completion. If the activity was canceled during execution on Landscape Client, it remains `Canceled` until Landscape Client reports the activity result.
+- `Succeeded`: Landscape Client reported a successful execution. This is a final state.
+
+### Life cycle of a client activity
+
+1. An activity is created for an instance (e.g., by an admin action or scheduled profile).
+1. The instance starts a message exchange with Landscape Server.
+1. Landscape moves the activity from `Queued` or `Scheduled` to `In Progress`.
+1. The activity is sent to the instance as a message containing an `operation-id`.
+1. Landscape Client stores the message metadata and calls the corresponding handler to execute the activity.
+1. Once done, Landscape Client creates an `operation-result` message containing the same `operation-id` and the result.
+1. The instance exchanges messages with Landscape Server again.
+1. Landscape Server receives the `operation-result` and updates the activity's status to `Succeeded` or `Failed`.
+
+## Server activities
+
+Server activities run on Landscape Server without interacting with Landscape Client. Examples include {ref}`downloading security profile reports <reference-rest-api-security-profiles>`. These activities are placed into a RabbitMQ queue and are processed by the `job-handler` service.
+
+### Server activity states
+
+Activities can start in the `Queued`, `Scheduled`, `Waiting`, or `Blocked` states.
+
+- `Queued`: Activity will run as soon as the `job-handler` service consumes this activity from the queue. Can transition to `In Progress`, `Canceled`, or `Blocked`.
+- `Scheduled`: Activity will run at a future time. Can transition to `Queued`, `In Progress`, or `Canceled`.
+- `Waiting`: Activity will not run until another activity completes or reaches a progress threshold. Can transition to `Queued`, `In Progress`, or `Canceled`.
+- `Blocked`: Activity is paused (often awaiting admin approval). Can transition to `Queued`, `Canceled`, or `Waiting`.
+- `In Progress`: Activity is running on the job handler. Can transition to `Failed`, `Succeeded`, or `Canceled`.
+- `Failed`: `job-handler` encountered an error while executing the activity. This is a final state.
+- `Canceled`: Activity was stopped before completion. This is a final state.
+- `Succeeded`: Activity completed successfully. This is a final state.
+
+### Life cycle of a server activity
+
+1. An activity is created (e.g., by an admin action or scheduled profile) and added to a RabbitMQ queue.
+1. The `job-handler` consumes the activity from the queue and moves the activity from `Queued` or `Scheduled` to `In Progress`.
+1. The `job-handler` completes the activity and updates the status to `Succeeded` or `Failed`.

--- a/docs/explanation/features/activities.md
+++ b/docs/explanation/features/activities.md
@@ -1,0 +1,12 @@
+(explanation-activities)=
+
+# Activities
+
+This document describes activities and outlines the services and steps involved for Landscape to complete activities.
+
+## Overview of activities
+
+# steps for how it communicates with client
+
+  message sent to client
+  client sends back operation status

--- a/docs/explanation/features/activities.md
+++ b/docs/explanation/features/activities.md
@@ -1,11 +1,11 @@
 (explanation-activities)=
 # Activities
 
-Landscape tracks the progress of various tasks using activities. There are two types of activities: client activities and server activities. This document will explain how each type of activity is tracked and their possible states.
+Landscape tracks the progress of various tasks using activities, such as script execution and installing packages. There are two types of activities: client activities and server activities. This document explains how each type of activity is tracked and their possible states.
 
 ## Client activities
 
-Client activities are tasks that execute on Landscape Client. Examples include {ref}`remote script execution <explanation-remote-script-execution>`. They are processed by the `message-system` when an instance exchanges messages with Landscape Server.
+Client activities are tasks that execute on Landscape Client. For example, {ref}`remote script execution <explanation-remote-script-execution>`. They are processed by the `message-system` when an instance exchanges messages with Landscape Server.
 
 ### Client activity states
 
@@ -33,7 +33,7 @@ Activities can start in the `Queued`, `Scheduled`, `Waiting`, or `Blocked` state
 
 ## Server activities
 
-Server activities run on Landscape Server without interacting with Landscape Client. Examples include {ref}`downloading security profile reports <reference-rest-api-security-profiles>`. These activities are placed into a RabbitMQ queue and are processed by the `job-handler` service.
+Server activities run on Landscape Server without interacting with Landscape Client. For example, {ref}`downloading security profile reports <reference-rest-api-security-profiles>`. These activities are placed into a RabbitMQ queue and are processed by the `job-handler` service.
 
 ### Server activity states
 
@@ -53,3 +53,45 @@ Activities can start in the `Queued`, `Scheduled`, `Waiting`, or `Blocked` state
 1. An activity is created (e.g., by an admin action or scheduled profile) and added to a RabbitMQ queue.
 1. The `job-handler` consumes the activity from the queue and moves the activity from `Queued` or `Scheduled` to `In Progress`.
 1. The `job-handler` completes the activity and updates the status to `Succeeded` or `Failed`.
+
+## Types of activities
+
+- `ResynchronizeRequest`
+- `CreateUserRequest`
+- `EditUserRequest`
+- `DeleteUserRequest`
+- `CreateGroupRequest`
+- `AddGroupMemberRequest`
+- `RemoveGroupMemberRequest`
+- `LockUserRequest`
+- `UnlockUserRequest`
+- `ChangePackagesRequest`
+- `UpgradeAllPackagesRequest`
+- `ReleaseUpgradeRequest`
+- `ChangePackageProfilesRequest`
+- `ChangeRepositoryProfilesRequest`
+- `ChangeUpgradeProfilesRequest`
+- `UpgradeKernelPackageRequest`
+- `DowngradeKernelPackageRequest`
+- `SignalProcessRequest`
+- `ExecuteScriptRequest`
+- `RestartRequest`
+- `ShutdownRequest`
+- `SyncPocketRequest`
+- `InstallSnaps`
+- `RemoveSnaps`
+- `RefreshSnaps`
+- `HoldSnaps`
+- `UnholdSnaps`
+- `StartChildComputerActivity`
+- `StopChildComputerActivity`
+- `DeleteChildComputerActivity`
+- `SetDefaultChildComputerActivity`
+- `ShutdownHostComputerActivity`
+- `CreateChildComputerActivity`
+- `DeleteUnmanagedWSLInstanceActivity`
+- `ArchiveRequest`
+- `UsgActivity`
+- `GenerateUsgReportActivity`
+- `RemoveComputerActivity`
+- `AttachProRequest`

--- a/docs/explanation/features/index.md
+++ b/docs/explanation/features/index.md
@@ -9,3 +9,4 @@ We have the following explanations for certain features in Landscape.
 
 repository-mirroring
 Package reporting <package-reporting>
+Remote script execution <remote-script-execution>

--- a/docs/explanation/features/index.md
+++ b/docs/explanation/features/index.md
@@ -7,6 +7,7 @@ We have the following explanations for certain features in Landscape.
 :titlesonly:
 :maxdepth: 2
 
+activities
 repository-mirroring
 Package reporting <package-reporting>
 Remote script execution <remote-script-execution>

--- a/docs/explanation/features/remote-script-execution.md
+++ b/docs/explanation/features/remote-script-execution.md
@@ -2,23 +2,74 @@
 
 # Landscape remote script execution
 
+This document explains how Landscape Client executes scripts.
+
 ## Overview
 
-## Services involved
+When an administrator requests a script execution, or when a script profile is scheduled, Landscape Server creates an `ExecuteScriptRequest` activity. See {ref}`explanation-activities` for details on how activities are delivered to clients.
 
-  message system
+### Attachments
 
-## Data stores involved
+Scripts may include attachments. Attachments are stored on Landscape Server, and clients can fetch them before execution.
 
-  account db
-  script files also in db
-  
-# creating activities -
+### `execute-script` message
 
-  script profile
-  manually running scripts
+Landscape Server sends a message to Landscape Client in the following form:
 
-# steps for how it communicates with client
+```json
+{
+  "type": "execute-script",
+  "interpreter": <interpreter>,
+  "code": <code>,
+  "username": <user>,
+  "time-limit": <time_limit>,
+  "operation-id": <activity_id>,
+  "attachments": <attachments>,
+  "env": {
+    "LANDSCAPE_ACCOUNT": <account_name>, 
+    "LANDSCAPE_COMPUTER_ID": <computer_id>,
+    "LANDSCAPE_COMPUTER_TAGS": <computer_tags>,
+    "LANDSCAPE_URL": <landscape_url>
+    "LANDSCAPE_ACTIVITY_ID": <activity_id>,
+    "LANDSCAPE_ACTIVITY_CREATOR_ID": <creator_id>,
+    "LANDSCAPE_ACTIVITY_CREATION_TIME": <creation_time>,
+  },
+}
+```
 
-  message sent to client
-  client sends back operation status
+Field descriptions:
+
+`interpreter`: The interpreter to run the script. This is parsed from the script code.
+`code`: The script body, excluding the interpreter line.
+`username`: The user under which the script will run. In the Landscape Client snap, this is always root.
+`time_limit`: Maximum execution time before the process is forcibly terminated.
+`activity_id`: Unique identifier of the activity.
+`attachments`: List of attachment IDs stored on Landscape Server.
+`env`: Environment variables provided by Landscape Server.
+`account_name`: The name of the account on Landscape Server.
+`computer_id`: The id of the computer.
+`landscape_url`: The Landscape Server root URL.
+`creator_id`: A unique id for the person that created the activity, if one exists.
+`creation_time`: The time the activity was created.
+
+### Script execution step-by-step
+
+The following section explains what happens on Landscape Client after receiving the above message.
+
+1. Landscape Client saves the message to the message store.
+1. Landscape Client passes the message to the script execution manager plugin.
+1. Landscape creates a temporary directory using `tempfile.mkdtemp`. The location is set with `--script-tempdir` or it will choose a default temporary directory, such as `/tmp/`.
+1. A file is created with 700 permissions in the temporary directory. If Landscape Client snap is running, the specified user is granted ownership of the file. The script is written to the file.
+1. The PATH environment variable is set to `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin`
+1. The USER and HOME environment variables are set to the provided user and corresponding home path, if any.
+1. The LANG, LC_ALL, LC_CTYPE, LD_LIBRARY_PATH, PYTHONPATH environment variables are copied from the root environment.
+1. All of the environment variables in "env" from the message are also set.
+1. If there are any attachments:
+   1. A new temporary directory is created with 700 permissions and ownership is granted if on the snap version.
+   1. Attachments are downloaded from Landscape Server using their unique identifiers into the temporary directory.
+   1. Each attachment is given 600 permissions and ownership if on the snap.
+   1. The LANDSCAPE_ATTACHMENTS environment variable is set to the temporary directory for attachments.
+1. The script is executed with the environment variables. The output is limited by the `script_output_limit` configuration.
+1. The script runs until it exits. If the time_limit is provided, the process will also exit after running for the provided time.
+1. If the LANDSCAPE_ATTACHMENTS environment variable is set, Landscape Client will remove the attachments directory tree.
+1. Landscape Client will send the output back to Landscape Server in an `operation-result` message. It will also report if the script was exited early due to timing out.

--- a/docs/explanation/features/remote-script-execution.md
+++ b/docs/explanation/features/remote-script-execution.md
@@ -1,16 +1,13 @@
 (explanation-remote-script-execution)=
+# Remote script execution
 
-# Landscape remote script execution
+Landscape has a remote script execution feature that allows administrators to run scripts on registered client machines from Landscape Server. You must have {ref}`script execution enabled <howto-heading-client-enable-script-execution>` to use this feature.
 
 This document explains how Landscape Client executes scripts.
 
 ## Overview
 
 When an administrator requests a script execution, or when a script profile is scheduled, Landscape Server creates an `ExecuteScriptRequest` activity. See {ref}`explanation-activities` for details on how activities are delivered to clients.
-
-## Attachments
-
-Scripts may include attachments. Attachments are stored on Landscape Server, and clients can fetch them before execution.
 
 ## `execute-script` message
 
@@ -39,13 +36,15 @@ Landscape Server sends a message to Landscape Client in the following form:
 
 Field descriptions:
 
-`interpreter`: The interpreter to run the script. This is parsed from the script code.
-`code`: The script body, excluding the interpreter line.
-`username`: The user under which the script will run. In the Landscape Client snap, this is always root.
-`time_limit`: Maximum execution time before the process is forcibly terminated.
-`activity_id`: Unique identifier of the activity.
-`attachments`: List of attachment IDs stored on Landscape Server.
-`env`: Environment variables provided by Landscape Server, including account name, computer metadata, and activity metadata.
+- `interpreter`: The interpreter to run the script. This is parsed from the script code.
+- `code`: The script body, excluding the interpreter line.
+- `username`: The user under which the script will run. If you're using the Landscape Client snap, this is always root.
+- `time_limit`: Maximum execution time before the process is forcibly terminated.
+- `activity_id`: Unique identifier of the activity.
+- `attachments`: List of attachment IDs stored on Landscape Server.
+- `env`: Environment variables provided by Landscape Server, including account name, computer metadata, and activity metadata.
+
+If an attachment is included in a script, the attachment is stored on Landscape Server. Clients can fetch attachments before executing the script.
 
 ## Execution flow on Landscape Client
 

--- a/docs/explanation/features/remote-script-execution.md
+++ b/docs/explanation/features/remote-script-execution.md
@@ -45,31 +45,29 @@ Field descriptions:
 `time_limit`: Maximum execution time before the process is forcibly terminated.
 `activity_id`: Unique identifier of the activity.
 `attachments`: List of attachment IDs stored on Landscape Server.
-`env`: Environment variables provided by Landscape Server.
-`account_name`: The name of the account on Landscape Server.
-`computer_id`: The id of the computer.
-`landscape_url`: The Landscape Server root URL.
-`creator_id`: A unique id for the person that created the activity, if one exists.
-`creation_time`: The time the activity was created.
+`env`: Environment variables provided by Landscape Server, including account name, computer metadata, and activity metadata.
 
-### Script execution step-by-step
+### Execution flow on Landscape Client
 
-The following section explains what happens on Landscape Client after receiving the above message.
+Once Landscape Client receives the `execute-script` message, it executes the following steps:
 
-1. Landscape Client saves the message to the message store.
-1. Landscape Client passes the message to the script execution manager plugin.
-1. Landscape creates a temporary directory using `tempfile.mkdtemp`. The location is set with `--script-tempdir` or it will choose a default temporary directory, such as `/tmp/`.
-1. A file is created with 700 permissions in the temporary directory. If Landscape Client snap is running, the specified user is granted ownership of the file. The script is written to the file.
-1. The PATH environment variable is set to `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin`
-1. The USER and HOME environment variables are set to the provided user and corresponding home path, if any.
-1. The LANG, LC_ALL, LC_CTYPE, LD_LIBRARY_PATH, PYTHONPATH environment variables are copied from the root environment.
-1. All of the environment variables in "env" from the message are also set.
-1. If there are any attachments:
-   1. A new temporary directory is created with 700 permissions and ownership is granted if on the snap version.
-   1. Attachments are downloaded from Landscape Server using their unique identifiers into the temporary directory.
-   1. Each attachment is given 600 permissions and ownership if on the snap.
-   1. The LANDSCAPE_ATTACHMENTS environment variable is set to the temporary directory for attachments.
-1. The script is executed with the environment variables. The output is limited by the `script_output_limit` configuration.
-1. The script runs until it exits. If the time_limit is provided, the process will also exit after running for the provided time.
-1. If the LANDSCAPE_ATTACHMENTS environment variable is set, Landscape Client will remove the attachments directory tree.
-1. Landscape Client will send the output back to Landscape Server in an `operation-result` message. It will also report if the script was exited early due to timing out.
+1. Save the message to the message store.
+1. Passes the message to the script execution manager plugin.
+1. Create a temporary file via `tempfile.mkstemp`. The directory location is defined by the `script_tempdir` configuration option or defaults to `/tmp/`.
+    1. File permissions are set to `700`.
+    1. In the snap version, the specified user is given ownership.
+1. Set up environment variables:
+    1. `PATH` -> `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin`
+    1. `USER` and `HOME` -> set according to the requested user.
+    1. `LANG`, `LC_ALL`, `LC_CTYPE`, `LD_LIBRARY_PATH`, `PYTHONPATH` -> copied from root.
+    1. All variables from the message's `env` block are set.
+1. If attachments are included:
+    1. Create a new temporary directory via `tempfile.mkdtemp`. The directory location is defined by the `script_tempdir` configuration or defaults to `/tmp/`. Give the directory `700` permissions. Give ownership to the specified user if on the snap.
+    1. Download attachments from Landscape Server using their IDs.
+    1. Save each attachment with `600` permissions to this temporary directory. Grant ownership if on the snap.
+    1. Set the `LANDSCAPE_ATTACHMENTS` environment variable to the attachments directory path.
+1. Execute the script with the configured environment.
+    1. The output is limited by the `script_output_limit` configuration.
+    1. Execution continues until the script exits or the `time_limit` is reached.
+1. If attachments were used, remove the attachments directory after execution.
+1. Send the results back to Landscape Server in an `operation-result` message, including script output and whether the script was terminated early due to timeout.

--- a/docs/explanation/features/remote-script-execution.md
+++ b/docs/explanation/features/remote-script-execution.md
@@ -8,32 +8,32 @@ This document explains how Landscape Client executes scripts.
 
 When an administrator requests a script execution, or when a script profile is scheduled, Landscape Server creates an `ExecuteScriptRequest` activity. See {ref}`explanation-activities` for details on how activities are delivered to clients.
 
-### Attachments
+## Attachments
 
 Scripts may include attachments. Attachments are stored on Landscape Server, and clients can fetch them before execution.
 
-### `execute-script` message
+## `execute-script` message
 
 Landscape Server sends a message to Landscape Client in the following form:
 
 ```json
 {
   "type": "execute-script",
-  "interpreter": <interpreter>,
-  "code": <code>,
-  "username": <user>,
-  "time-limit": <time_limit>,
-  "operation-id": <activity_id>,
-  "attachments": <attachments>,
+  "interpreter": "INTERPRETER",
+  "code": "SCRIPT_CODE",
+  "username": "USER",
+  "time-limit": "TIME_LIMIT",
+  "operation-id": "ACTIVITY_ID",
+  "attachments": ["ATTACHMENT_IDS"],
   "env": {
-    "LANDSCAPE_ACCOUNT": <account_name>, 
-    "LANDSCAPE_COMPUTER_ID": <computer_id>,
-    "LANDSCAPE_COMPUTER_TAGS": <computer_tags>,
-    "LANDSCAPE_URL": <landscape_url>
-    "LANDSCAPE_ACTIVITY_ID": <activity_id>,
-    "LANDSCAPE_ACTIVITY_CREATOR_ID": <creator_id>,
-    "LANDSCAPE_ACTIVITY_CREATION_TIME": <creation_time>,
-  },
+    "LANDSCAPE_ACCOUNT": "ACCOUNT_NAME",
+    "LANDSCAPE_COMPUTER_ID": "COMPUTER_ID",
+    "LANDSCAPE_COMPUTER_TAGS": ["COMPUTER_TAGS"],
+    "LANDSCAPE_URL": "LANDSCAPE_URL",
+    "LANDSCAPE_ACTIVITY_ID": "ACTIVITY_ID",
+    "LANDSCAPE_ACTIVITY_CREATOR_ID": "CREATOR_ID",
+    "LANDSCAPE_ACTIVITY_CREATION_TIME": "CREATION_TIME"
+  }
 }
 ```
 
@@ -47,7 +47,7 @@ Field descriptions:
 `attachments`: List of attachment IDs stored on Landscape Server.
 `env`: Environment variables provided by Landscape Server, including account name, computer metadata, and activity metadata.
 
-### Execution flow on Landscape Client
+## Execution flow on Landscape Client
 
 Once Landscape Client receives the `execute-script` message, it executes the following steps:
 

--- a/docs/explanation/features/remote-script-execution.md
+++ b/docs/explanation/features/remote-script-execution.md
@@ -1,0 +1,24 @@
+(explanation-remote-script-execution)=
+
+# Landscape remote script execution
+
+## Overview
+
+## Services involved
+
+  message system
+
+## Data stores involved
+
+  account db
+  script files also in db
+  
+# creating activities -
+
+  script profile
+  manually running scripts
+
+# steps for how it communicates with client
+
+  message sent to client
+  client sends back operation status

--- a/docs/reference/api/rest-api-endpoints/security_profiles.md
+++ b/docs/reference/api/rest-api-endpoints/security_profiles.md
@@ -1,3 +1,4 @@
+(reference-rest-api-security-profiles)=
 # Security Profiles
 
 The endpoints available here are related to management of security profiles.


### PR DESCRIPTION
added activities and script execution explanation

I separated activities into "Client activities", which are sent to instances and "Server activities", which are not sent to instances

For Activities, I tried to separate it from the inner workings of message system as much as I could.

For script execution, I mainly focused on what happens on Landscape Client
