### PR TITLE
Add rediraffe extension

### DIFF
--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -3,3 +3,4 @@ sphinx-autobuild
 sphinxcontrib-svg2pdfconverter[CairoSVG]
 sphinx-last-updated-by-git
 sphinx-sitemap
+sphinxext-rediraffe

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -190,7 +190,8 @@ extensions = [
     "canonical_sphinx",
     "sphinxcontrib.cairosvgconverter",
     "sphinx_last_updated_by_git",
-    "sphinx_sitemap"
+    "sphinx_sitemap",
+    "sphinxext.rediraffe"
 ]
 
 
@@ -278,21 +279,18 @@ sitemap_url_scheme = "{link}"
 # Redirects #
 #############
 
-# To set up redirects: https://documatt.gitlab.io/sphinx-reredirects/usage.html
-# For example: 'explanation/old-name.html': '../how-to/prettify.html',
+## Rediraffe extension
+rediraffe_branch = "main"
+rediraffe_redirects = "redirects.txt"
 
-# To set up redirects in the Read the Docs project dashboard:
-# https://docs.readthedocs.io/en/stable/guides/redirects.html
-
-# NOTE: If undefined, set to None, or empty,
-#       the sphinx_reredirects extension will be disabled.
-
+## Reredirects extension 
+## NOTE: We've moved to use rediraffe as our main redirects extension.
+## The following are ones we already had in place, but haven't migrated
 redirects = {
     'how-to-guides/landscape-installation-and-set-up/install-on-google-cloud': '../cloud-providers/install-on-google-cloud',
     'how-to-guides/landscape-installation-and-set-up/install-on-microsoft-azure': '../cloud-providers/install-on-microsoft-azure',
     'how-to-guides/security/manage-repositories-in-an-air-gapped-or-offline-environment': '../../repository-mirrors/manage-repositories-in-an-air-gapped-or-offline-environment',
     'how-to-guides/security/install-landscape-in-an-air-gapped-or-offline-environment': '../../landscape-installation-and-set-up/install-landscape-in-an-air-gapped-or-offline-environment',
-    'getting-started-with-landscape': '/tutorial',
     'explanation/repository-mirroring/repository-mirroring': '../../features/repository-mirroring',
     'reference/known-issues/known-issues': '../../known-issues'
 }

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -1,0 +1,15 @@
+# The redirects.txt file stores redirects for the published docs
+# If you change a filename, move or delete a file, you need a redirect here.
+# - Comment lines start with a hash (#) and are ignored
+# - Each redirect should appear on its own line
+
+# We are using the dirhtml builder, so files are treated as directories:
+# - A file is built like `filename/index.html`, not `filename.html`
+# - *Do* include a trailing slash at the end of the path
+# - *Do not* include a file extension or you'll get errors
+# - Paths don't need a slash in front of them
+
+# Example:
+# redirect/from/file/ redirect/to/file/
+
+getting-started-with-landscape tutorial/


### PR DESCRIPTION
Note that the redirects include `index.html` at the end. This is how it also is in the Ubuntu Server docs though, so I'll leave it as is for now, but checking in with the Docs team.