### PR TITLE
fix(ubuntuinstaller): missed installer 24.04 notes

### DIFF
--- a/docs/how-to-guides/ubuntu-installer/configure-landscape-deployment-for-autoinstall-provisioning.md
+++ b/docs/how-to-guides/ubuntu-installer/configure-landscape-deployment-for-autoinstall-provisioning.md
@@ -1,7 +1,7 @@
 (how-to-ubuntu-installer-configure-landscape-deployment)=
 # How to configure your Landscape deployment to provision workstations with Autoinstall via the Ubuntu installer
 
-The Ubuntu installer (24.04 and later) can use Landscape to serve an autoinstall file. Your Landscape account must use OIDC authentication.
+The Ubuntu installer (26.04 and later) can use Landscape to serve an autoinstall file. Your Landscape account must use OIDC authentication.
 
 ```{note}
 This feature is available from Landscape server `25.10~beta.4` onwards.

--- a/docs/how-to-guides/ubuntu-installer/set-up-autoinstall-provisioning.md
+++ b/docs/how-to-guides/ubuntu-installer/set-up-autoinstall-provisioning.md
@@ -1,7 +1,7 @@
 (how-to-ubuntu-installer-set-up-landscape)=
 # How to set up your Landscape server to provision workstations with Autoinstall via the Ubuntu installer
 
-The Ubuntu installer (24.04 and later) can use Landscape to serve an autoinstall file. This is available on self-hosted and Landscape SaaS. On Landscape SaaS, your account must be hosted on a subdomain. Your Landscape account must use OIDC authentication.
+The Ubuntu installer (26.04 and later) can use Landscape to serve an autoinstall file. This is available on self-hosted and Landscape SaaS. On Landscape SaaS, your account must be hosted on a subdomain. Your Landscape account must use OIDC authentication.
 
 ```{note}
 This feature is available from Landscape server `25.10~beta.4` onwards.


### PR DESCRIPTION
I missed correcting 24.04 -> 26.04 in some other places when adjusting the installer version this is available in.