### PR TITLE
fix: Update missing URLs

### DIFF
--- a/docs/explanation/landscape/self-hosted-landscape.md
+++ b/docs/explanation/landscape/self-hosted-landscape.md
@@ -81,6 +81,12 @@ The machine(s) running as the application server will also need the following ex
  * HTTPS access to `usn.ubuntu.com` in order to download the USN database and detect security updates. Without this, the available updates won't be distinguished between security related and regular updates
  * HTTP access to the public Ubuntu archives and `changelogs.ubuntu.com`, in order to update the hash-id-database files and detect new distribution releases. Without this, the release upgrade feature won't work
  * HTTPS access to `landscape.canonical.com` in order to query for available self-hosted Landscape releases. If this access is not given, the only drawback is that Landscape won't display a note about the available releases in the account page.
+ * HTTPS access to `ppa.launchpadcontent.net` if using the Landscape quickstart PPA
+ * HTTPS access to `contracts.canonical.com` for Ubuntu Pro authentication
+ * HTTPS access to `esm.ubuntu.com` for Ubuntu Pro APT package-based services
+ * HTTPS access to `livepatch.canonical.com` and `livepatch-files.canonical.com` for Livepatch
+ * HTTPS access to `ubuntu.com/security` for fetching security information
+ * HTTPS access to `api.snapcraft.io`, `dashboard.snapcraft.io`, `login.ubuntu.com`, and `*.snapcraftcontent.com` if using or downloading snaps (e.g., `landscape-api`)
 
 If this external network access is unavailable, Canonical's professional services include assistance with setting up Landscape in a fully air-gapped environment.
 


### PR DESCRIPTION
Addressed this reported issue: https://github.com/canonical/landscape-documentation/issues/114
