### PR TITLE
add warning for CreateCloudOtps legacy endpoint

### DIFF
--- a/docs/reference/api/legacy-api-endpoints/computers.md
+++ b/docs/reference/api/legacy-api-endpoints/computers.md
@@ -364,6 +364,10 @@ landscape-api reject-pending-computers 1,2
 
 ## CreateCloudOtps
 
+```{warning}
+CreateCloudOtps is no longer available from Landscape Server 25.04 onwards
+```
+
 Create one-time passwords used for registration of cloud instances:
 
 ```text


### PR DESCRIPTION
The `CreateCloudOtps` endpoint was removed from Landscape Server in  the 25.04 release, I have added a warning on the documentation for the endpoint to reflect that. 