### PR TITLE
fix: Refresh Legacy API

### DIFF
--- a/docs/how-to-guides/api/use-the-legacy-api-via-http-requests.md
+++ b/docs/how-to-guides/api/use-the-legacy-api-via-http-requests.md
@@ -33,7 +33,7 @@ Here's an example request:
 1.  Obtain a JWT:
 
     ```bash
-    TOKEN=$(curl -s -X POST "https://<LANDSCAPE-HOSTNAME>/api/v2/login" \
+    TOKEN=$(curl -s -X POST "https://<LANDSCAPE-HOSTNAME>/api/login" \
       -H "Content-Type: application/json" \
       -d '{"email": "<YOUR-EMAIL>", "password": "<YOUR-PASSWORD>"}' | jq -r '.token')
     ```


### PR DESCRIPTION
## Context
https://github.com/canonical/landscape-documentation/pull/123
https://warthogs.atlassian.net/browse/LNDENG-3252

The legacy API does not have "v2" in it. Small change to remove it from the legacy API example.
