### PR TITLE
fix(ubuntuinstaller) remove reference to SaaS OIDC

### DIFF
--- a/docs/how-to-guides/ubuntu-installer/set-up-autoinstall-provisioning.md
+++ b/docs/how-to-guides/ubuntu-installer/set-up-autoinstall-provisioning.md
@@ -27,14 +27,7 @@ Landscape uses OIDC authentication for the workstation provisioning experience.
 
 Only users that are known to the OIDC provider will be able to use the provisioning experience. A local Landscape user that logs in with username/password will not.
 
-### Self-hosted
-
 See {ref}`how-to-external-auth-oidc`.
-
-### SaaS
-
-1. Navigate to **Org settings > Identity providers**.
-2. Configure an OIDC provider.
 
 ## Create and test your autoinstall file
 


### PR DESCRIPTION
This is only available on self-hosted at the moment, so it doesn't make sense to reference SaaS OIDC.