### PR TITLE
fix: remove access group parameter from profile edit endpoints

### DIFF
--- a/docs/reference/api/rest-api-endpoints/child-instance-profiles.md
+++ b/docs/reference/api/rest-api-endpoints/child-instance-profiles.md
@@ -33,7 +33,7 @@ Example request:
 curl -X GET -H "Authorization: Bearer $JWT" "https://landscape.canonical.com/api/v2/child-instance-profile-types"
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -67,7 +67,7 @@ Example request:
 curl -X GET https://landscape.canonical.com/api/v2/child-instance-profiles?search=ubuntu -H "Authorization: Bearer $JWT"
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -130,7 +130,7 @@ curl -X POST https://landscape.canonical.com/api/v2/child-instance-profiles -H "
 curl -X POST https://landscape.canonical.com/api/v2/child-instance-profiles -H "Authorization: Bearer $JWT" -d '{"title": "Custom Rootfs Image", "description": "My custom image", "image_name": "CustomUbuntu", "image_source": "https://example.com/myimage.tar.gz"}'
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -175,9 +175,7 @@ Example request:
 curl -X DELETE https://landscape.canonical.com/api/v2/child-instance-profiles/stock-ubuntu-2404 -H "Authorization: Bearer $JWT"
 ```
 
-Example output:
-
-Empty response.
+This endpoint returns an empty response.
 
 ## GET `/child-instance-profiles/<string:profile_name>`
 
@@ -197,7 +195,7 @@ Example request:
 curl -X GET https://landscape.canonical.com/api/v2/child-instance-profiles/stock-ubuntu-2404 -H "Authorization: Bearer $JWT"
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -236,7 +234,6 @@ Optional parameters:
 
 - `title`: A title for the profile.
 - `description`: A human readable description for the profile.
-- `access_group`: Name of the access group for the profile under.
 - `tags`: A list of tag names to associate with the profile.
 - `all_computers`: Whether or not to associate this profile with all computers.
 
@@ -246,7 +243,7 @@ Example request:
 curl -X PATCH https://landscape.canonical.com/api/v2/child-instance-profiles/stock-ubuntu-2404 -H "Authorization: Bearer $JWT" -d '{"description": "The stock image from the store", "tags": ["windows_laptops"]}'
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -327,7 +324,7 @@ Example requests:
 curl -X POST https://landscape.canonical.com/api/v2/child-instance-profiles/make-hosts-compliant -H "Authorization: Bearer $JWT" -d '{"host_computer_ids": [6, 15]}'
 ```
 
-Example output:
+Example response:
 
 ```json
 {

--- a/docs/reference/api/rest-api-endpoints/reboot-profiles.md
+++ b/docs/reference/api/rest-api-endpoints/reboot-profiles.md
@@ -38,7 +38,7 @@ curl -X POST "https://landscape.canonical.com/api/v2/rebootprofiles"  \
 }'
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -79,7 +79,6 @@ Optional parameters:
 - `all_computers`: Whether to apply this reboot profile to all computers.
 - `deliver_within`: Number of hours within which the task should be delivered.
 - `deliver_delay_window`: Randomize delivery within this number of minutes.
-- `access_group`: The access group name where the profile is stored.
 - `tags`: A list of computer tags to target instead of `all_computers`.
 
 Example request:
@@ -93,7 +92,7 @@ curl -X PATCH "https://landscape.canonical.com/api/v2/rebootprofiles/11" \
 }'
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -130,7 +129,7 @@ Example request:
 curl -X GET "https://landscape.canonical.com/api/v2/rebootprofiles?limit=2" -H "Authorization: Bearer $JWT"
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -190,6 +189,4 @@ Example request:
 curl -X DELETE "https://landscape.canonical.com/api/v2/rebootprofiles/1" -H "Authorization: Bearer $JWT"
 ```
 
-Example output:
-
-_(empty response)_
+This endpoint returns an empty response.

--- a/docs/reference/api/rest-api-endpoints/script_profiles.md
+++ b/docs/reference/api/rest-api-endpoints/script_profiles.md
@@ -8,9 +8,9 @@ Get script profiles associated with the current account, ordered by creation tim
 
 Optional query parameters:
 
-  - `archived`: the status of the script profile to filter by. Can be one of `archived`, `active` or `all`. Defaults to `active`.
-  - `offset`: The offset inside the list of results, used for pagination.
-  - `limit`: The maximum number of results returned, defaults to 1000.
+- `archived`: the status of the script profile to filter by. Can be one of `archived`, `active` or `all`. Defaults to `active`.
+- `offset`: The offset inside the list of results, used for pagination.
+- `limit`: The maximum number of results returned, defaults to 1000.
 
 Example request:
 
@@ -19,7 +19,7 @@ curl -X GET https://landscape.canonical.com/api/v2/script-profiles?archived=all 
 curl -X GET https://landscape.canonical.com/api/v2/script-profiles -H "Authorization: Bearer $JWT"
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -143,7 +143,7 @@ Get a script profile by `id`.
 
 Path parameters:
 
-  - `id`: The identification number of the profile.
+- `id`: The identification number of the profile.
 
 Example request:
 
@@ -151,7 +151,7 @@ Example request:
 curl -X GET https://landscape.canonical.com/api/v2/script-profiles/116782 -H "Authorization: Bearer $JWT"
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -194,14 +194,13 @@ Create a script profile.
 
 Required parameters:
 
-  - `title`: The display name of the profile.
-  - `script_id`: The id of the script this profile is associated with, must be a `v2` script.
-  - `all_computers`: If `true`, the profile will be applied to all instances in the script's `access_group`, regardless of `tags`.
-  - `tags`: An array of tag strings. The profile will be applied only to instances with these tags in the script's `access_group`.
-  - `time_limit`: The time, in seconds, after which the script is considered defunct.
-                  The process will be killed, and the script execution will be marked as failed after this limit expires.
-  - `username`: The username to execute the script as on the client.
-  - `trigger`: Defined as a [trigger](#trigger) based on which the profile should execute.
+- `title`: The display name of the profile.
+- `script_id`: The id of the script this profile is associated with, must be a `v2` script.
+- `all_computers`: If `true`, the profile will be applied to all instances in the script's `access_group`, regardless of `tags`.
+- `tags`: An array of tag strings. The profile will be applied only to instances with these tags in the script's `access_group`.
+- `time_limit`: The time, in seconds, after which the script is considered defunct. The process will be killed, and the script execution will be marked as failed after this limit expires.
+- `username`: The username to execute the script as on the client.
+- `trigger`: Defined as a [trigger](#trigger) based on which the profile should execute.
 
 Example request:
 
@@ -221,7 +220,7 @@ curl -X POST "https://landscape.canonical.com/api/v2/script-profiles" -H "Author
 }'
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -256,23 +255,23 @@ Example output:
 ### Trigger
 
 Required parameters:
-  - `trigger_type`: Either of `event`, `one_time`, `recurring`.
+
+- `trigger_type`: Either of `event`, `one_time`, `recurring`.
 
 Each `trigger_type` has corresponding required parameters.
 
 #### Event
 
-   - `event_type`: Currently only the `post_enrollment` event is available, which triggers after a computer is enrolled in an account.
+- `event_type`: Currently only the `post_enrollment` event is available, which triggers after a computer is enrolled in an account.
 
 #### One Time
 
-  - `timestamp`: An ISO 8601-formatted datestamp that sets when the profile should execute.
-                 If it is in the past, the profile will start its first run immediately.
+- `timestamp`: An ISO 8601-formatted datestamp that sets when the profile should execute. If it is in the past, the profile will start its first run immediately.
 
 #### Recurring
 
-  - `start_after`: An ISO 8601-formatted datestamp that sets the earliest time after which the profile should be scheduled to execute.
-  - `interval`: A 5 digit, [Cron](https://en.wikipedia.org/wiki/Cron) string.
+- `start_after`: An ISO 8601-formatted datestamp that sets the earliest time after which the profile should be scheduled to execute.
+- `interval`: A 5 digit, [Cron](https://en.wikipedia.org/wiki/Cron) string.
 
 ## PATCH `/script-profiles/<id>`
 
@@ -280,17 +279,16 @@ Update a script profile.
 
 Path parameters:
 
-  - `id`: The identification number of the profile to update.
+- `id`: The identification number of the profile to update.
 
 Optional parameters:
 
-  - `title`: The display name of the profile.
-  - `all_computers`: If `true`, the profile will be applied to all instances in the script's `access_group`, regardless of `tags`.
-  - `tags`: An array of tag strings. The profile will be applied only to instances with these tags in the script's `access_group`.
-  - `time_limit`: The time, in seconds, after which the script is considered defunct.
-                  The process will be killed, and the script execution will be marked as failed after this limit expires.
-  - `username`: The username to execute the script as on the client.
-  - `trigger`: Defined as a [trigger](#trigger) based on which the profile should execute.
+- `title`: The display name of the profile.
+- `all_computers`: If `true`, the profile will be applied to all instances in the script's `access_group`, regardless of `tags`.
+- `tags`: An array of tag strings. The profile will be applied only to instances with these tags in the script's `access_group`.
+- `time_limit`: The time, in seconds, after which the script is considered defunct. The process will be killed, and the script execution will be marked as failed after this limit expires.
+- `username`: The username to execute the script as on the client.
+- `trigger`: Defined as a [trigger](#trigger) based on which the profile should execute.
 
 Example request:
 
@@ -305,7 +303,7 @@ curl -X PATCH "https://landscape.canonical.com/api/v2/script-profiles/176892" -H
 }
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -345,7 +343,7 @@ Archive a script profile. This makes it inactive.
 
 Path parameters:
 
-  - `id`: The identification number of the profile to archive.
+- `id`: The identification number of the profile to archive.
 
 Example request:
 
@@ -359,9 +357,9 @@ Get parent activities associated with a script profile ordered by creation time.
 
 Path parameters:
 
-  - `id`: The identification number of the profile.
-  - `offset`: The offset inside the list of results, used for pagination.
-  - `limit`: The maximum number of results returned, defaults to 1000.
+- `id`: The identification number of the profile.
+- `offset`: The offset inside the list of results, used for pagination.
+- `limit`: The maximum number of results returned, defaults to 1000.
 
 Example request:
 
@@ -369,7 +367,7 @@ Example request:
 curl -X POST "https://landscape.canonical.com/api/v2/script-profiles/176892/activities" -H "Authorization: Bearer $JWT"
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -408,7 +406,7 @@ Example request:
 curl -X POST "https://landscape.canonical.com/api/v2/script-profile-limits" -H "Authorization: Bearer $JWT"
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -418,4 +416,4 @@ Example output:
 }
 ```
 
-  - `min_interval`: The minimum time, in minutes, between execution of recurring script profiles that Landscape enforces.
+- `min_interval`: The minimum time, in minutes, between execution of recurring script profiles that Landscape enforces.

--- a/docs/reference/api/rest-api-endpoints/security_profiles.md
+++ b/docs/reference/api/rest-api-endpoints/security_profiles.md
@@ -9,17 +9,12 @@ Get security profiles associated with the current account, paginated and ordered
 
 Optional query parameters:
 
-  - `search`: filters profiles to only those with titles containing the provided string.
-  - `status`: must be either `archived` or `active`. Filters profiles to those with the selected
-     status.
-  - `pass_rate_from`: an integer from 0 to 100. Filters profiles to those with a pass rate at or
-     above the value.
-  - `pass_rate_to`: an integer from 0 to 100. Filters profiles to those with a pass rate at or below
-     the value.
-  - `limit`: a positive integer used for pagination. Limits the results to the given number of
-     profiles.
-  - `offset`: a non-negative integer used for pagination. Offsets the start of the results by the
-     given number of profiles.
+- `search`: filters profiles to only those with titles containing the provided string.
+- `status`: must be either `archived` or `active`. Filters profiles to those with the selected status.
+- `pass_rate_from`: an integer from 0 to 100. Filters profiles to those with a pass rate at or above the value.
+- `pass_rate_to`: an integer from 0 to 100. Filters profiles to those with a pass rate at or below the value.
+- `limit`: a positive integer used for pagination. Limits the results to the given number of profiles.
+- `offset`: a non-negative integer used for pagination. Offsets the start of the results by the given number of profiles.
 
 Example request:
 
@@ -27,7 +22,7 @@ Example request:
 curl -X GET https://landscape.canonical.com/api/v2/security-profiles -H "Authorization: Bearer $JWT"
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -107,21 +102,20 @@ Create a security profile. The new security profile will perform its first run a
 
 Required parameters:
 
-  - `benchmark`: The USG benchmark the security profile will enforce. See the [Ubuntu Security Guide](https://ubuntu.com/security/certifications/docs/usg) for options.
-  - `mode`: The run mode of the profile. One of `"audit"`, `"fix-audit"`, or `"fix-restart-audit"`.
-  - `schedule`: An [RFC 5545 "Recurrence Rule"](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10), determining how frequently the profile will audit its instances. Cannot be more frequent than weekly.
-  - `title`: The display name of the profile.
-  - `start_date`: An ISO 8601-formatted datestamp that sets the first run time of the profile. If
-     it is the current date or in the past, the profile will start its first run immediately.
+- `benchmark`: The USG benchmark the security profile will enforce. See the [Ubuntu Security Guide](https://ubuntu.com/security/certifications/docs/usg) for options.
+- `mode`: The run mode of the profile. One of `"audit"`, `"fix-audit"`, or `"fix-restart-audit"`.
+- `schedule`: An [RFC 5545 "Recurrence Rule"](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10), determining how frequently the profile will audit its instances. Cannot be more frequent than weekly.
+- `title`: The display name of the profile.
+- `start_date`: An ISO 8601-formatted datestamp that sets the first run time of the profile. If it is the current date or in the past, the profile will start its first run immediately.
 
 Optional parameters:
 
-  - `access_group`: The instance access group to apply the profile to. Defaults to `"global"`.
-  - `all_computers`: If `true`, the profile will be applied to all instances in `access_group`, regardless of `tags`.
-  - `restart_deliver_delay`: If `mode` is `"fix-restart-audit"`, delays the delivery of restart activities by this many hours after fix.
-  - `restart_deliver_delay_window`: If `mode` is `"fix-restart-audit"`, randomizes delivery of restart activities within the number of minutes provided
-  - `tags`: An array of tag strings. The profile will be applied only to instances with these tags.
-  - `tailoring_file`: The contents of an XML file used to customize which `benchmark` rules are applied during audit or fix. If provided, the `benchmark` parameter is ignored.
+- `access_group`: The instance access group to apply the profile to. Defaults to `"global"`.
+- `all_computers`: If `true`, the profile will be applied to all instances in `access_group`, regardless of `tags`.
+- `restart_deliver_delay`: If `mode` is `"fix-restart-audit"`, delays the delivery of restart activities by this many hours after fix.
+- `restart_deliver_delay_window`: If `mode` is `"fix-restart-audit"`, randomizes delivery of restart activities within the number of minutes provided
+- `tags`: An array of tag strings. The profile will be applied only to instances with these tags.
+- `tailoring_file`: The contents of an XML file used to customize which `benchmark` rules are applied during audit or fix. If provided, the `benchmark` parameter is ignored.
 
 Example request:
 
@@ -141,7 +135,7 @@ curl -X POST "https://landscape.canonical.com/api/v2/security-profiles" -H "Auth
 }'
 ```
 
-Example output, the profile's state:
+Example response, the profile's state:
 
 ```json
 {
@@ -184,17 +178,16 @@ Update a security profile. Be aware that not every field is editable.
 
 Path parameters:
 
-  - `id`: The identification number of the profile to update.
-  
+- `id`: The identification number of the profile to update.
+
 Optional parameters:
 
-  - `access_group`: The instance access group to apply the profile to.
-  - `all_computers`: If `true`, the profile will be applied to all instances in `access_group`, regardless of `tags`.
-  - `restart_deliver_delay`: If `mode` is `"fix-restart-audit"`, delays the delivery of restart activities by this many hours after fix.
-  - `restart_deliver_delay_window`: If `mode` is `"fix-restart-audit"`, randomizes delivery of restart activities within the number of minutes provided
-  - `schedule`: An [RFC 5545 "Recurrence Rule"](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10), determining how frequently the profile will audit its instances. Cannot be more frequent than weekly.
-  - `tags`: An array of tag strings. The profile will be applied only to instances with these tags.
-  - `title`: The display name of the profile.
+- `all_computers`: If `true`, the profile will be applied to all instances in `access_group`, regardless of `tags`.
+- `restart_deliver_delay`: If `mode` is `"fix-restart-audit"`, delays the delivery of restart activities by this many hours after fix.
+- `restart_deliver_delay_window`: If `mode` is `"fix-restart-audit"`, randomizes delivery of restart activities within the number of minutes provided
+- `schedule`: An [RFC 5545 "Recurrence Rule"](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10), determining how frequently the profile will audit its instances. Cannot be more frequent than weekly.
+- `tags`: An array of tag strings. The profile will be applied only to instances with these tags.
+- `title`: The display name of the profile.
   
 Example request:
 
@@ -207,7 +200,7 @@ curl -X PATCH "https://landscape.canonical.com/api/v2/security-profiles/1" -H "A
 }'
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -249,7 +242,7 @@ Archive a security profile. This makes it inactive.
 
 Path parameters:
 
-  - `id`: The identification number of the profile to archive.
+- `id`: The identification number of the profile to archive.
   
 Example request:
 
@@ -257,7 +250,7 @@ Example request:
 curl -X POST "https://landscape.canonical.com/api/v2/security-profiles/1:archive" -H "Authorization: Bearer $JWT"
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -299,7 +292,7 @@ Returns the created activity.
 
 Path parameters:
 
-  - `id`: The identification number of the profile to execute.
+- `id`: The identification number of the profile to execute.
 
 Example request:
 
@@ -307,7 +300,7 @@ Example request:
 curl -X POST "https://landscape.canonical.com/api/v2/security-profiles/1:execute" -H "Authorization: Bearer $JWT"
 ```
 
-Example output:
+Example response:
 
 ```json
 {
@@ -337,29 +330,26 @@ requested report. The URI can be used with the `/security-profiles/blob` endpoin
 
 Path parameters:
 
-  - `id`: The identification number of the profile the report applies to.
-  
+- `id`: The identification number of the profile the report applies to.
+
 Required query parameters:
 
-  - `start_date`: the start time for the data that the report should include. If it is the only
-    parameter provided, then only data from the run at this time will be included.
-    
+- `start_date`: the start time for the data that the report should include. If it is the only parameter provided, then only data from the run at this time will be included.
+
 Optional query parameters:
 
-  - `end_date`: the end time for the data that the report should include. If it is provided, then
-    data from runs that occurred from `start_date` to `end_date` will be included.
-  - `detailed`: if `true`, then a detailed report will be provided instead of a summary report.
-    Defaults to `false`.
-    
+- `end_date`: the end time for the data that the report should include. If it is provided, then data from runs that occurred from `start_date` to `end_date` will be included.
+- `detailed`: if `true`, then a detailed report will be provided instead of a summary report. Defaults to `false`.
+
 Example requests:
-    
+
 ```bash
 curl -X GET "https://landscape.canonical.com/api/v2/security-profiles/1/report?start_date=2025-02-28T12:34Z" -H "Authorization: Bearer $JWT"
 
 curl -X GET "https://landscape.canonical.com/api/v2/security-profiles/1/report?start_date=2025-02-26&end_date=2025-03-02&detailed=true" -H "Authorization: Bearer $JWT"
 ```
 
-Example output (when a report already exists):
+Example response (when a report already exists):
 
 ```json
 {
@@ -370,7 +360,7 @@ Example output (when a report already exists):
 }
 ```
 
-Example output (when a report will be created):
+Example response (when a report will be created):
 
 ```json
 {
@@ -429,16 +419,15 @@ Returns the file for the given `path`. This could be a compliance report or a ta
 
 Required query parameters:
 
-  - `path`: the path of the file, as retrieved from `/security-profiles/<id>/report` or the status
-    of a security profile from `/security-profiles` or `/security-profiles/<id>`.
-    
+- `path`: the path of the file, as retrieved from `/security-profiles/<id>/report` or the status of a security profile from `/security-profiles` or `/security-profiles/<id>`.
+
 Example request:
 
 ```bash
 curl -X GET "https://landscape.canonical.com/api/v2/security-profiles/blob?path=Landscape_security_profile_audit_report_ID1-20250218.csv" -H "Authorization: Bearer $JWT"
 ```
 
-Example output:
+Example response:
 
 ```json
 {

--- a/docs/reference/release-notes/24-04-lts-release-notes.md
+++ b/docs/reference/release-notes/24-04-lts-release-notes.md
@@ -10,11 +10,11 @@
 ## Highlights
 
 - **New web portal:** Use Landscape’s new, early-access web portal built with Canonical’s [Vanilla Framework](https://vanillaframework.io). 
-    
+
     ![Landscape 24.04 LTS new web portal](https://assets.ubuntu.com/v1/ef0d70d5-24.04LandscapeWebPortal.png)
 
     This portal is available to self-hosted Landscape users. To access it, click **Try the new UI** from the header of the default web portal. The first time you use the portal, you may need to generate new API credentials to access the portal. For more information, see {ref}`how to generate API credentials <howto-heading-manage-repos-web-portal-generate-api-credentials>`.
-    
+
 - **Web-based repository management**: Manage and mirror your repositories locally with Landscape’s new web-based repository management. For more information, see {ref}`how-to-manage-repos-web-portal` and an {ref}`explanation-repo-mirroring`.
 
 - **REST API for self-hosted users**: Use the new REST API that supports JSON Web Tokens for authentication. For more information, see {ref}`how-to-rest-api-request` and the available REST API endpoints.


### PR DESCRIPTION
We should not allow editing the access group of any profile.

Check that

1. No REST API PATCH endpoint for profiles has a documented access group parameter
2. No Legacy API endpoint for editing a profile has a documents access group parameter.
