### PR TITLE
feat: 24.04.12 release notes

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -54,6 +54,7 @@ Charmhub's
 changelog
 checkboxes
 Chocolatey
+chrony
 CIDR
 CIS
 CISOs
@@ -391,6 +392,7 @@ Xenial
 xenial
 Xerus
 XSS
+Zope
 
 # Partial words (e.g., amd from amd64)
 amd

--- a/docs/reference/release-notes/24-04-lts-release-notes.md
+++ b/docs/reference/release-notes/24-04-lts-release-notes.md
@@ -109,3 +109,21 @@ We published the 24.04.11 point release on 27 October 2025.
  - fix: Event logs reference wrong computer
  - fix: hide static/asset directory listings
  - fix: Change dependency on chrony to depend on the time-daemon virtual package instead
+
+## Landscape 24.04.12 Point Release
+
+We published the 24.04.12 point release on 17 April 2026.
+
+ - fix: hide inputs when there is a validation error
+ - fix: issue with pro free licenses
+ - fix: user enumeration on password reset page
+ - fix: html escape account title in invitation email
+ - fix: arbitrary file deletion bug in package upload
+ - fix: check for application/json content-type header in POST,PUT,PATCH requests
+ - fix: block cross-site request forgery via GET-based state modifications
+ - fix: Backport pingserver fixes
+ - fix: force download for all script attachments
+ - fix: backport-cross-site scripting in the profile creation page
+ - fix: backport-cross-site-scripting-activity-result-page
+ - fix: remove newlines from proxy config
+ - fix: Zope template security bugs

--- a/docs/reference/release-notes/24-04-lts-release-notes.md
+++ b/docs/reference/release-notes/24-04-lts-release-notes.md
@@ -119,7 +119,7 @@ We published the 24.04.12 point release on 17 April 2026.
  - fix: user enumeration on password reset page
  - fix: html escape account title in invitation email
  - fix: arbitrary file deletion bug in package upload
- - fix: check for application/json content-type header in POST,PUT,PATCH requests
+ - fix!: check for application/json content-type header in POST,PUT,PATCH requests
  - fix: block cross-site request forgery via GET-based state modifications
  - fix: Backport pingserver fixes
  - fix: force download for all script attachments

--- a/docs/reference/release-notes/24-04-lts-release-notes.md
+++ b/docs/reference/release-notes/24-04-lts-release-notes.md
@@ -98,3 +98,14 @@ We published the 24.04.10 point release on 27 February 2025.
  - fix: prevent epoll race conditions when writing API responses
  - fix: reset passphrase oops backport (LP: [#2094844](https://bugs.launchpad.net/landscape/+bug/2094844))
  - fix: 500 error when logging out in standalone
+
+## Landscape 24.04.11 Point Release
+
+We published the 24.04.11 point release on 27 October 2025.
+
+ - fix: remove unused _buffer_type import; safe import of AbstractComputerRequest
+ - fix: raise client error for invalid GPG material in POST /gpg-key
+ - fix: ignore root-url update on conflict
+ - fix: Event logs reference wrong computer
+ - fix: hide static/asset directory listings
+ - fix: Change dependency on chrony to depend on the time-daemon virtual package instead


### PR DESCRIPTION
I also included 24.04.11 release notes from the changelog, I did not find them anywhere in the docs. Once this is approved I will upload the release to `landscape/self-hosted-24.04` PPA and then merge this in. 

Test upload: https://launchpad.net/~joey-mucci/+archive/ubuntu/self-hosted-24.04