### PR TITLE
add etc/host instruction to quickstart install guide

### DIFF
--- a/docs/how-to-guides/landscape-installation-and-set-up/quickstart-installation.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/quickstart-installation.md
@@ -56,6 +56,7 @@ To set the machine’s host name, run:
 
 ```bash
 sudo hostnamectl set-hostname "$FQDN"
+echo "127.0.1.1 $FQDN" | sudo tee -a /etc/hosts
 ```
 
 When Landscape Server is installed, it'll read the machine’s host name and use it in the Apache configuration.


### PR DESCRIPTION
This change ensures compatibility with server side changes to how the quickstart installation sets the root url.