### PR TITLE
feat: create landscape upgrade guide (26.04)

### DIFF
--- a/docs/how-to-guides/upgrade/index.md
+++ b/docs/how-to-guides/upgrade/index.md
@@ -14,7 +14,7 @@ Upgrade your Landscape Server deployment to newer versions. These guides cover s
 :maxdepth: 1
 
 Upgrade Landscape <upgrade-landscape>
-Upgrade to Landscape 24.04 LTS <upgrade-to-24-04-lts>
 Upgrade to Landscape 26.04 LTS <upgrade-to-26-04-lts>
+Upgrade to Landscape 24.04 LTS <upgrade-to-24-04-lts>
 ```
 

--- a/docs/how-to-guides/upgrade/index.md
+++ b/docs/how-to-guides/upgrade/index.md
@@ -15,5 +15,6 @@ Upgrade your Landscape Server deployment to newer versions. These guides cover s
 
 Upgrade Landscape <upgrade-landscape>
 Upgrade to Landscape 24.04 LTS <upgrade-to-24-04-lts>
+Upgrade to Landscape 26.04 LTS <upgrade-to-26-04-lts>
 ```
 

--- a/docs/how-to-guides/upgrade/upgrade-landscape.md
+++ b/docs/how-to-guides/upgrade/upgrade-landscape.md
@@ -140,3 +140,5 @@ To upgrade a basic Juju deployment:
 Landscape commonly has version-specific configurations that must be added to complete your upgrade.
 
 If you're upgrading to Landscape 24.04 LTS, follow {ref}`how-to-upgrade-to-24-04-lts`.
+
+If you're upgrading to Landscape 26.04 LTS, follow {ref}`how-to-upgrade-to-26-04-lts`.

--- a/docs/how-to-guides/upgrade/upgrade-landscape.md
+++ b/docs/how-to-guides/upgrade/upgrade-landscape.md
@@ -135,9 +135,9 @@ To upgrade a basic Juju deployment:
     juju run landscape-server/n resume
     ```
 
-## Add additional configurations
+## Additional steps needed by version
 
-Landscape commonly has version-specific configurations that must be added to complete your upgrade.
+Landscape commonly has version-specific steps that must be taken to complete your upgrade.
 
 If you're upgrading to Landscape 24.04 LTS, follow {ref}`how-to-upgrade-to-24-04-lts`.
 

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -58,7 +58,7 @@ sudo snap logs landscape-outbox -n 50
 
 ### (WSL only) Enable hostagent services
 
-These steps are only needed for WSL users. The hostagent services (`landscape-hostagent-consumer` and `landscape-hostagent-messenger`) are required to manage WSL instances via Ubuntu Pro for WSL. See the configuration docs for the [hostagent consumer](/reference/config/service-conf.md/#the-hostagent-consumer-section) and [hostagent messenger](/reference/config/service-conf.md/#the-hostagent-messenger-section) to set up these services.
+These steps are only needed for WSL users. The hostagent services (`landscape-hostagent-consumer` and `landscape-hostagent-messenger`) are required to manage WSL instances via Ubuntu Pro for WSL. See the configuration docs for the {ref}`hostagent consumer <hostagent-consumer-section>` and {ref}`hostagent messenger<hostagent-messenger-section>` to set up these services.
 
 If you don't configure the hostagent services, you won't be able to use WSL with Landscape. Other activities unrelated to WSL will still function properly.
 

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -48,7 +48,7 @@ The `landscape-debarchive` snap is required for repository mirroring from Landsc
 
 ### (WSL only) Enable hostagent services
 
-These steps are only needed for WSL users. The hostagent services (`landscape-hostagent-consumer` and `landscape-hostagent-messenger`) are required to manage WSL instances via Ubuntu Pro for WSL. Follow the steps in [the hostagent_consumer section](/reference/config/service-conf.md/#the-hostagent-consumer-section) and [the hostagent_messenger section](/reference/config/service-conf.md/#the-hostagent-messenger-section) to configure these services. 
+These steps are only needed for WSL users. The hostagent services (`landscape-hostagent-consumer` and `landscape-hostagent-messenger`) are required to manage WSL instances via Ubuntu Pro for WSL. See the configuration docs for the [hostagent consumer](/reference/config/service-conf.md/#the-hostagent-consumer-section) and [hostagent messenger](/reference/config/service-conf.md/#the-hostagent-messenger-section) to set up these services. 
 
 If you don't configure the hostagent services, you won't be able to use WSL with Landscape. Other activities unrelated to WSL will still function properly.
 

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -23,7 +23,7 @@ If you upgraded from a version prior to 25.10, your `service.conf` file will be 
 
 ## Additional upgrade steps
 
-After you’ve completed the basic upgrade instructions, you need to make some additional manual changes to finish your upgrade.
+After you’ve completed the basic upgrade instructions and have the updated `service.conf` file, you need to make some additional manual changes to finish your upgrade.
 
 ### Install the outbox snap
 

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -46,7 +46,7 @@ sudo snap logs landscape-outbox
 
 The `landscape-debarchive` snap is required for repository mirroring from Landscape 26.04 LTS onwards. Follow the instructions in the [dedicated guide](/docs/how-to-guides/landscape-installation-and-setup/debarchive-repository-management.md)
 
-### Enable hostagent services (optional)
+### (WSL only) Enable hostagent services
 
 The hostagent services (`landscape-hostagent-consumer` and `landscape-hostagent-messenger`) are required to manage WSL instances via Ubuntu Pro for WSL. See [the hostagent_consumer section](/reference/config/service-conf.md/#the-hostagent-consumer-section) and [the hostagent_messenger section](/reference/config/service-conf.md/#the-hostagent-messenger-section) if you'd like to configure these services. If not configured, these services will fail to start, but all Landscape activities unrelated to WSL will still function properly.
 

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -66,9 +66,9 @@ After transferring the files to the airgapped environment, install the snaps.
 
 ```bash
 sudo snap ack landscape-outbox_*.assert
-sudo snap install landscape-outbox_*.assert
+sudo snap install landscape-outbox_*.snap
 sudo snap ack landscape-debarchive_*.assert
-sudo snap install landscape-debarchive_*.assert
+sudo snap install landscape-debarchive_*.snap
 ```
 
 Finally, verify the snaps are working properly according to the instructions above.

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -27,7 +27,7 @@ If you upgraded from a version prior to 25.10, your `service.conf` file will be 
 
 After you’ve completed the basic upgrade instructions, you need to make some additional manual changes to finish your upgrade.
 
-### Install the outbox Snap
+### Install the outbox snap
 
 The `landscape-outbox` snap is critical to proper functioning of Landscape 26.04 LTS. Install the `landscape-outbox` snap on the same machine as your Landscape Server installation.
 
@@ -44,9 +44,31 @@ sudo snap logs landscape-outbox
 
 ### Install the debarchive snap
 
-
 The `landscape-debarchive` snap is required for repository mirroring from Landscape 26.04 LTS onwards. Follow the instructions in the [dedicated guide](/docs/how-to-guides/landscape-installation-and-setup/debarchive-repository-management.md)
 
 ### Enable hostagent services (optional)
 
 The hostagent services (`landscape-hostagent-consumer` and `landscape-hostagent-messenger`) are required to manage WSL instances via Ubuntu Pro for WSL. See [the hostagent_consumer section](/reference/config/service-conf.md/#the-hostagent-consumer-section) and [the hostagent_messenger section](/reference/config/service-conf.md/#the-hostagent-messenger-section) if you'd like to configure these services. If not configured, these services will fail to start, but all Landscape activities unrelated to WSL will still function properly.
+
+## Airgapped installations
+If your deployment does not have internet access, you must carry the snaps into your airgapped environment as part of the 26.04 installation process.
+
+First, in an environment with internet access, download the snaps.
+
+```bash
+snap download landscape-outbox
+snap download landscape-debacrhive --edge
+```
+
+For each snap, a `.snap` file and a `.assert` file will be produced.
+
+After transferring the files to the airgapped environment, install the snaps.
+
+```bash
+sudo snap ack landscape-outbox_*.assert
+sudo snap install landscape-outbox_*.assert
+sudo snap ack landscape-debarchive_*.assert
+sudo snap install landscape-debarchive_*.assert
+```
+
+Finally, verify the snaps are working properly according to the instructions above.

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -1,8 +1,46 @@
 ---
 myst:
   html_meta:
-    description: "TODO: FILL IN"
+    description: "Upgrade Landscape Server to 26.04 LTS from Ubuntu 22.04, 24.04 or 26.04. Install additional outbox and repository mirroring services as snaps.
 ---
 
 (how-to-upgrade-to-26-04-lts)=
 # How to upgrade to Landscape Server 26.04 LTS
+
+```{important}
+If you are using repository mirroring in your Landscape deployment, you should not attempt to upgrade to 26.04 LTS at this time. A migration guide for bringing over repository mirrors from 24.04 LTS to 26.04 LTS will be published at a later date.
+```
+
+To upgrade your self-hosted Landscape server to 26.04 LTS, you should first follow the basic upgrade instructions. See {ref}`how-to-upgrade`.
+
+Note that you must be running Ubuntu 26.04 LTS Resolute Raccoon, 24.04 Noble Numbat, or 22.04 Jammy Jellyfish to upgrade to Landscape 26.04 LTS.
+
+## Additional upgrade steps
+
+After you’ve completed the basic upgrade instructions, you need to make some additional manual changes to finish your upgrade.
+
+### Install the outbox Snap
+
+The `landscape-outbox` snap is critical to proper functioning of Landscape 26.04 LTS. Install the `landscape-outbox` snap on the same machine as your Landscape Server installation.
+
+```bash
+sudo snap install landscape-outbox
+```
+
+`landscape-outbox` is configured to work automatically with an existing Landscape Server by default. Check that the outbox is active and functioning properly.
+
+```bash
+sudo snap services landscape-outbox
+sudo snap logs landscape-outbox
+```
+
+### Install the debarchive snap
+
+
+The `landscape-debarchive` snap is required for repository mirroring from Landscape 26.04 LTS onwards. Install the `landscape-debarchive` snap on the same machine as your Landscape Server installation.
+
+...
+
+### Enable hostagent services (optional)
+
+The hostagent services (`landscape-hostagent-consumer` and `landscape-hostagent-messenger`) are required to manage WSL instances via Ubuntu Pro for WSL. See [the hostagent_consumer section](/reference/config/service-conf.md/#the-hostagent-consumer-section) and [the hostagent_messenger section](/reference/config/service-conf.md/#the-hostagent-messenger-section) if you'd like to configure these services. If not configured, these services will fail to start, but all Landscape activities unrelated to WSL will still function properly.

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -57,7 +57,7 @@ First, in an environment with internet access, download the snaps.
 
 ```bash
 snap download landscape-outbox
-snap download landscape-debacrhive --edge
+snap download landscape-debarchive --edge
 ```
 
 For each snap, a `.snap` file and a `.assert` file will be produced.

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -19,7 +19,7 @@ To upgrade your self-hosted Landscape server to 26.04 LTS, you should first foll
 
 ## Additional upgrade steps
 
-After you’ve completed the basic upgrade instructions and have the updated `service.conf` file, you need to make some additional manual changes to finish your upgrade.
+After you’ve completed the basic upgrade instructions, you need to make some additional manual changes to finish your upgrade.
 
 ### Install the outbox snap
 

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -11,6 +11,10 @@ myst:
 If you are using repository mirroring in your Landscape deployment, you should not attempt to upgrade to 26.04 LTS at this time. A migration guide for bringing over repository mirrors from 24.04 LTS to 26.04 LTS will be published at a later date.
 ```
 
+```{important}
+Quickstart installations and upgrades to Landscape 26.04 LTS are not supported on Ubuntu 26.04.
+```
+
 To upgrade your self-hosted Landscape server to 26.04 LTS, you should first follow the basic upgrade instructions. See {ref}`how-to-upgrade`.
 
 Note that you must be running Ubuntu 26.04 LTS Resolute Raccoon, 24.04 Noble Numbat, or 22.04 Jammy Jellyfish to upgrade to Landscape 26.04 LTS.

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -15,6 +15,10 @@ To upgrade your self-hosted Landscape server to 26.04 LTS, you should first foll
 
 Note that you must be running Ubuntu 26.04 LTS Resolute Raccoon, 24.04 Noble Numbat, or 22.04 Jammy Jellyfish to upgrade to Landscape 26.04 LTS.
 
+## Service.conf migration
+
+If you upgraded from a version prior to 25.10, your `service.conf` file will be migrated away from our deprecated naming system during the upgrade. A backup file from before the migration will be supplied in the same directory as your `service.conf`. Support for the deprecated config options is expected to be removed in the 26.10 release. See {ref}`reference-service-conf` for more details.
+
 ## Additional upgrade steps
 
 After you’ve completed the basic upgrade instructions, you need to make some additional manual changes to finish your upgrade.

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -41,9 +41,7 @@ sudo snap logs landscape-outbox
 ### Install the debarchive snap
 
 
-The `landscape-debarchive` snap is required for repository mirroring from Landscape 26.04 LTS onwards. Install the `landscape-debarchive` snap on the same machine as your Landscape Server installation.
-
-...
+The `landscape-debarchive` snap is required for repository mirroring from Landscape 26.04 LTS onwards. Follow the instructions in the [dedicated guide](/docs/how-to-guides/landscape-installation-and-setup/debarchive-repository-management.md)
 
 ### Enable hostagent services (optional)
 

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -1,0 +1,8 @@
+---
+myst:
+  html_meta:
+    description: "TODO: FILL IN"
+---
+
+(how-to-upgrade-to-26-04-lts)=
+# How to upgrade to Landscape Server 26.04 LTS

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -7,17 +7,15 @@ myst:
 (how-to-upgrade-to-26-04-lts)=
 # How to upgrade to Landscape Server 26.04 LTS
 <!-- TODO add when the release notes exist: See also: {ref}`reference-release-notes-26-04-lts` -->
-```{important}
-If you are using repository mirroring in your Landscape deployment, you should not attempt to upgrade to 26.04 LTS at this time. A migration guide for bringing over repository mirrors from 24.04 LTS to 26.04 LTS will be published at a later date.
-```
+You must be running Ubuntu 26.04 LTS Resolute Raccoon, 24.04 Noble Numbat, or 22.04 Jammy Jellyfish to upgrade to Landscape 26.04 LTS.
 
-```{important}
-Quickstart installations and upgrades to Landscape 26.04 LTS are not supported on Ubuntu 26.04.
-```
+Note that Quickstart installations and upgrades to Landscape 26.04 LTS are not supported on Ubuntu 26.04. You must use Ubuntu 24.04 LTS or 22.04 LTS for Quickstart installations.
+
+If you use repository management in your Landscape deployment, we recommend waiting to upgrade to 26.04 LTS until the 26.04.1 point release (expected August 2026). A migration guide for bringing over repository mirrors from 24.04 LTS to 26.04 LTS will be published before the point release.
+
+## Begin your upgrade
 
 To upgrade your self-hosted Landscape server to 26.04 LTS, you should first follow the basic upgrade instructions. See {ref}`how-to-upgrade`.
-
-Note that you must be running Ubuntu 26.04 LTS Resolute Raccoon, 24.04 Noble Numbat, or 22.04 Jammy Jellyfish to upgrade to Landscape 26.04 LTS.
 
 ## Service.conf migration
 
@@ -44,7 +42,7 @@ sudo snap logs landscape-outbox
 
 ### Install the debarchive snap
 
-<!-- TODO add when the release notes exist: The `landscape-debarchive` snap is required for repository mirroring from Landscape 26.04 LTS onwards. Follow the instructions in the [dedicated guide](/docs/how-to-guides/landscape-installation-and-setup/debarchive-repository-management.md) -->
+<!-- TODO add when the release notes exist: The `landscape-debarchive` snap is required for repository management from Landscape 26.04 LTS onwards. Follow the instructions in the [dedicated guide](/docs/how-to-guides/landscape-installation-and-setup/debarchive-repository-management.md) -->
 
 ### (WSL only) Enable hostagent services
 

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -6,7 +6,7 @@ myst:
 
 (how-to-upgrade-to-26-04-lts)=
 # How to upgrade to Landscape Server 26.04 LTS
-
+> <!-- TODO add when the release notes exist: See also: {ref}`reference-release-notes-26-04-lts` -->
 ```{important}
 If you are using repository mirroring in your Landscape deployment, you should not attempt to upgrade to 26.04 LTS at this time. A migration guide for bringing over repository mirrors from 24.04 LTS to 26.04 LTS will be published at a later date.
 ```

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Upgrade Landscape Server to 26.04 LTS from Ubuntu 22.04, 24.04 or 26.04. Install additional outbox and repository mirroring services as snaps."
+    description: "Upgrade Landscape Server to 26.04 LTS from Ubuntu 22.04, 24.04, or 26.04. Install additional outbox and repository mirroring services as snaps."
 ---
 
 (how-to-upgrade-to-26-04-lts)=
@@ -19,7 +19,7 @@ To upgrade your self-hosted Landscape server to 26.04 LTS, you should first foll
 
 ## Service.conf migration
 
-If you upgraded from a version prior to 25.10, your `service.conf` file will be migrated away from our deprecated naming system during the upgrade. A backup file from before the migration will be supplied in the same directory as your `service.conf`. Support for the deprecated config options is expected to be removed in the 26.10 release. See {ref}`reference-service-conf` for more details.
+If you upgraded from a version prior to 25.10, your `service.conf` file will be migrated away from the deprecated naming system during the upgrade. A backup file from before the migration will be provided in the same directory as your `service.conf`. Support for the deprecated config options is expected to be removed in the 26.10 release. See {ref}`reference-service-conf` for more details.
 
 ## Additional upgrade steps
 
@@ -27,17 +27,29 @@ After you’ve completed the basic upgrade instructions and have the updated `se
 
 ### Install the outbox snap
 
-The `landscape-outbox` snap is critical to proper functioning of Landscape 26.04 LTS. Install the `landscape-outbox` snap on the same machine as your Landscape Server installation.
+Install the `landscape-outbox` snap on the same machine as your Landscape Server installation.
 
 ```bash
 sudo snap install landscape-outbox
 ```
 
-`landscape-outbox` is configured to work automatically with an existing Landscape Server by default. Check that the outbox is active and functioning properly.
+`landscape-outbox` is configured to work automatically with an existing Landscape Server by default. Confirm that the snap service is running.
 
 ```bash
 sudo snap services landscape-outbox
-sudo snap logs landscape-outbox
+```
+
+The output should show the `outbox` service as **active**:
+
+```bash
+Service                  Startup  Current  Notes
+landscape-outbox.outbox  enabled  active   -
+```
+
+To view outbox logs, run:
+
+```bash
+sudo snap logs landscape-outbox -n 50
 ```
 
 ### Install the debarchive snap
@@ -46,12 +58,12 @@ sudo snap logs landscape-outbox
 
 ### (WSL only) Enable hostagent services
 
-These steps are only needed for WSL users. The hostagent services (`landscape-hostagent-consumer` and `landscape-hostagent-messenger`) are required to manage WSL instances via Ubuntu Pro for WSL. See the configuration docs for the [hostagent consumer](/reference/config/service-conf.md/#the-hostagent-consumer-section) and [hostagent messenger](/reference/config/service-conf.md/#the-hostagent-messenger-section) to set up these services. 
+These steps are only needed for WSL users. The hostagent services (`landscape-hostagent-consumer` and `landscape-hostagent-messenger`) are required to manage WSL instances via Ubuntu Pro for WSL. See the configuration docs for the [hostagent consumer](/reference/config/service-conf.md/#the-hostagent-consumer-section) and [hostagent messenger](/reference/config/service-conf.md/#the-hostagent-messenger-section) to set up these services.
 
 If you don't configure the hostagent services, you won't be able to use WSL with Landscape. Other activities unrelated to WSL will still function properly.
 
-## Airgapped installations
-If your deployment does not have internet access, you must carry the snaps into your airgapped environment as part of the 26.04 installation process.
+## Airgapped environments
+If your deployment does not have internet access, you must carry the snaps into your airgapped environment as part of the 26.04 upgrade process.
 
 First, in an environment with internet access, download the snaps.
 
@@ -70,5 +82,3 @@ sudo snap install landscape-outbox_*.snap
 sudo snap ack landscape-debarchive_*.assert
 sudo snap install landscape-debarchive_*.snap
 ```
-
-Finally, verify the snaps are working properly according to the instructions above.

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -6,7 +6,7 @@ myst:
 
 (how-to-upgrade-to-26-04-lts)=
 # How to upgrade to Landscape Server 26.04 LTS
-> <!-- TODO add when the release notes exist: See also: {ref}`reference-release-notes-26-04-lts` -->
+<!-- TODO add when the release notes exist: See also: {ref}`reference-release-notes-26-04-lts` -->
 ```{important}
 If you are using repository mirroring in your Landscape deployment, you should not attempt to upgrade to 26.04 LTS at this time. A migration guide for bringing over repository mirrors from 24.04 LTS to 26.04 LTS will be published at a later date.
 ```
@@ -44,7 +44,7 @@ sudo snap logs landscape-outbox
 
 ### Install the debarchive snap
 
-The `landscape-debarchive` snap is required for repository mirroring from Landscape 26.04 LTS onwards. Follow the instructions in the [dedicated guide](/docs/how-to-guides/landscape-installation-and-setup/debarchive-repository-management.md)
+<!-- TODO add when the release notes exist: The `landscape-debarchive` snap is required for repository mirroring from Landscape 26.04 LTS onwards. Follow the instructions in the [dedicated guide](/docs/how-to-guides/landscape-installation-and-setup/debarchive-repository-management.md) -->
 
 ### (WSL only) Enable hostagent services
 

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -48,7 +48,9 @@ The `landscape-debarchive` snap is required for repository mirroring from Landsc
 
 ### (WSL only) Enable hostagent services
 
-The hostagent services (`landscape-hostagent-consumer` and `landscape-hostagent-messenger`) are required to manage WSL instances via Ubuntu Pro for WSL. See [the hostagent_consumer section](/reference/config/service-conf.md/#the-hostagent-consumer-section) and [the hostagent_messenger section](/reference/config/service-conf.md/#the-hostagent-messenger-section) if you'd like to configure these services. If not configured, these services will fail to start, but all Landscape activities unrelated to WSL will still function properly.
+These steps are only needed for WSL users. The hostagent services (`landscape-hostagent-consumer` and `landscape-hostagent-messenger`) are required to manage WSL instances via Ubuntu Pro for WSL. Follow the steps in [the hostagent_consumer section](/reference/config/service-conf.md/#the-hostagent-consumer-section) and [the hostagent_messenger section](/reference/config/service-conf.md/#the-hostagent-messenger-section) to configure these services. 
+
+If you don't configure the hostagent services, you won't be able to use WSL with Landscape. Other activities unrelated to WSL will still function properly.
 
 ## Airgapped installations
 If your deployment does not have internet access, you must carry the snaps into your airgapped environment as part of the 26.04 installation process.

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -17,10 +17,6 @@ If you use repository management in your Landscape deployment, we recommend wait
 
 To upgrade your self-hosted Landscape server to 26.04 LTS, you should first follow the basic upgrade instructions. See {ref}`how-to-upgrade`.
 
-## Service.conf migration
-
-If you upgraded from a version prior to 25.10, your `service.conf` file will be migrated away from the deprecated naming system during the upgrade. A backup file from before the migration will be provided in the same directory as your `service.conf`. Support for the deprecated config options is expected to be removed in the 26.10 release. See {ref}`reference-service-conf` for more details.
-
 ## Additional upgrade steps
 
 After you’ve completed the basic upgrade instructions and have the updated `service.conf` file, you need to make some additional manual changes to finish your upgrade.

--- a/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
+++ b/docs/how-to-guides/upgrade/upgrade-to-26-04-lts.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Upgrade Landscape Server to 26.04 LTS from Ubuntu 22.04, 24.04 or 26.04. Install additional outbox and repository mirroring services as snaps.
+    description: "Upgrade Landscape Server to 26.04 LTS from Ubuntu 22.04, 24.04 or 26.04. Install additional outbox and repository mirroring services as snaps."
 ---
 
 (how-to-upgrade-to-26-04-lts)=

--- a/docs/reference/config/service-conf.md
+++ b/docs/reference/config/service-conf.md
@@ -461,6 +461,7 @@ The `[broker]` section contains configurations that describe how services connec
 - ENV name: `LANDSCAPE_BROKER__VHOST`
 - Default: `landscape`
 
+(hostagent-consumer-section)=
 ## The `[hostagent_consumer]` section
 
 ```{note}
@@ -471,6 +472,7 @@ The `[hostagent_consumer]` section contains settings for the `landscape-hostagen
 
 This entire section is optional. Omitting the `[hostagent_consumer]` section entirely will cause the `landscape-hostagent-consumer` service to stop immediately after it starts.
 
+(hostagent-messenger-section)=
 ## The `[hostagent_messenger]` section
 
 ```{note}


### PR DESCRIPTION
This is still a work in progress mainly since I couldn't verify the debarchive feature. I have hit the main points and added a placeholder disclaimer about the upgrade with repository mirrors that can be replaced as necessary.

Other points I'd like to address before merging

- Will both snaps be on a non-edge channel by docs publication? If not, we'll need to add `--edge` to the install instructions. 
- What's the airgapped story? I can test this next and add instructions accordingly. Would the 26.04 guide be the right place for those instructions?