### PR TITLE
feat: add 26.04 installation guidance

### DIFF
--- a/docs/how-to-guides/landscape-installation-and-set-up/install-landscape-in-an-air-gapped-or-offline-environment.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/install-landscape-in-an-air-gapped-or-offline-environment.md
@@ -43,12 +43,34 @@ sudo apt --download-only -y install landscape-server-quickstart
 
 All of the necessary packages for Landscape Server should now be downloaded to the APT cache directory: `/var/cache/apt/archives`.
 
+#### (26.04 only) Download the Landscape Server snap services
+
+Landscape 26.04 LTS depends on two snap services, `landscape-outbox` and `landscape-debarchive`, which are downloaded separately.
+
+```bash
+snap download landscape-outbox
+snap download landscape-debarchive --edge
+```
+
+For each snap, a `.snap` file and a `.assert` file will be produced.
+
 ### Install Landscape Server in the offline environment
 
 Copy the downloaded `.deb` packages, carry them into the offline or airgapped environment, and manually transfer and install them onto your machine with `dpkg`. You can install the packages with a command similar to:
 
 ```bash
 sudo dpkg -i /PATH/TO/PACKAGES/*.deb
+```
+
+#### (26.04 only) Install the Landscape Server snap services
+
+Copy the downloaded snap artifacts, carry them into the offline or airgapped environment, and install them with `snap`. You can install the packages with a command similar to:
+
+```bash
+sudo snap ack landscape-outbox_*.assert
+sudo snap install landscape-outbox_*.snap
+sudo snap ack landscape-debarchive_*.assert
+sudo snap install landscape-debarchive_*.snap
 ```
 
 Once Landscape Server is installed, you can finish setting up Landscape similar to how you would with an online server. See the {ref}`Quickstart <how-to-quickstart-installation>` and {ref}`Manual <how-to-manual-installation>` installation guides for more details. This also includes setting up your first administrator and attaching your {ref}`explanation-licenses`.

--- a/docs/how-to-guides/landscape-installation-and-set-up/install-landscape-in-an-air-gapped-or-offline-environment.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/install-landscape-in-an-air-gapped-or-offline-environment.md
@@ -43,7 +43,7 @@ sudo apt --download-only -y install landscape-server-quickstart
 
 All of the necessary packages for Landscape Server should now be downloaded to the APT cache directory: `/var/cache/apt/archives`.
 
-#### (26.04 only) Download the Landscape Server snap services
+#### (Landscape 26.04 only) Download the Landscape Server snap services
 
 Landscape 26.04 LTS depends on two snap services, `landscape-outbox` and `landscape-debarchive`, which are downloaded separately.
 
@@ -62,7 +62,7 @@ Copy the downloaded `.deb` packages, carry them into the offline or airgapped en
 sudo dpkg -i /PATH/TO/PACKAGES/*.deb
 ```
 
-#### (26.04 only) Install the Landscape Server snap services
+#### (Landscape 26.04 only) Install the Landscape Server snap services
 
 Copy the downloaded snap artifacts, carry them into the offline or airgapped environment, and install them with `snap`. You can install the packages with a command similar to:
 

--- a/docs/how-to-guides/landscape-installation-and-set-up/manual-installation.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/manual-installation.md
@@ -571,7 +571,7 @@ Use `lsctl`:
 sudo lsctl restart
 ```
 
-### (26.04 only) Install the outbox snap
+### (Landscape 26.04 only) Install the outbox snap
 
 Install the `landscape-outbox` snap on the same machine as your Landscape Server installation.
 
@@ -598,7 +598,7 @@ To view outbox logs, run:
 sudo snap logs landscape-outbox -n 50
 ```
 
-### (26.04 only) Install the debarchive snap
+### (Landscape 26.04 only) Install the debarchive snap
 
 <!-- TODO add when the release notes exist: The `landscape-debarchive` snap is required for repository management from Landscape 26.04 LTS onwards. Follow the instructions in the [dedicated guide](/docs/how-to-guides/landscape-installation-and-setup/debarchive-repository-management.md) -->
 

--- a/docs/how-to-guides/landscape-installation-and-set-up/manual-installation.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/manual-installation.md
@@ -283,6 +283,37 @@ Without this setting enabled, a package update might result in services that won
 
 - Start all Landscape services again
 
+### (26.04 only) Install the outbox snap
+
+Install the `landscape-outbox` snap on the same machine as your Landscape Server installation.
+
+```bash
+sudo snap install landscape-outbox
+```
+
+`landscape-outbox` is configured to work automatically with an existing Landscape Server by default. Confirm that the snap service is running.
+
+```bash
+sudo snap services landscape-outbox
+```
+
+The output should show the `outbox` service as **active**:
+
+```bash
+Service                  Startup  Current  Notes
+landscape-outbox.outbox  enabled  active   -
+```
+
+To view outbox logs, run:
+
+```bash
+sudo snap logs landscape-outbox -n 50
+```
+
+### (26.04 only) Install the debarchive snap
+
+<!-- TODO add when the release notes exist: The `landscape-debarchive` snap is required for repository management from Landscape 26.04 LTS onwards. Follow the instructions in the [dedicated guide](/docs/how-to-guides/landscape-installation-and-setup/debarchive-repository-management.md) -->
+
 (how-to-heading-manual-install-configure-web-server)=
 ### Configure web server
 

--- a/docs/how-to-guides/landscape-installation-and-set-up/manual-installation.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/manual-installation.md
@@ -283,36 +283,6 @@ Without this setting enabled, a package update might result in services that won
 
 - Start all Landscape services again
 
-### (26.04 only) Install the outbox snap
-
-Install the `landscape-outbox` snap on the same machine as your Landscape Server installation.
-
-```bash
-sudo snap install landscape-outbox
-```
-
-`landscape-outbox` is configured to work automatically with an existing Landscape Server by default. Confirm that the snap service is running.
-
-```bash
-sudo snap services landscape-outbox
-```
-
-The output should show the `outbox` service as **active**:
-
-```bash
-Service                  Startup  Current  Notes
-landscape-outbox.outbox  enabled  active   -
-```
-
-To view outbox logs, run:
-
-```bash
-sudo snap logs landscape-outbox -n 50
-```
-
-### (26.04 only) Install the debarchive snap
-
-<!-- TODO add when the release notes exist: The `landscape-debarchive` snap is required for repository management from Landscape 26.04 LTS onwards. Follow the instructions in the [dedicated guide](/docs/how-to-guides/landscape-installation-and-setup/debarchive-repository-management.md) -->
 
 (how-to-heading-manual-install-configure-web-server)=
 ### Configure web server
@@ -600,6 +570,37 @@ Use `lsctl`:
 ```bash
 sudo lsctl restart
 ```
+
+### (26.04 only) Install the outbox snap
+
+Install the `landscape-outbox` snap on the same machine as your Landscape Server installation.
+
+```bash
+sudo snap install landscape-outbox
+```
+
+`landscape-outbox` is configured to work automatically with an existing Landscape Server by default. Confirm that the snap service is running.
+
+```bash
+sudo snap services landscape-outbox
+```
+
+The output should show the `outbox` service as **active**:
+
+```bash
+Service                  Startup  Current  Notes
+landscape-outbox.outbox  enabled  active   -
+```
+
+To view outbox logs, run:
+
+```bash
+sudo snap logs landscape-outbox -n 50
+```
+
+### (26.04 only) Install the debarchive snap
+
+<!-- TODO add when the release notes exist: The `landscape-debarchive` snap is required for repository management from Landscape 26.04 LTS onwards. Follow the instructions in the [dedicated guide](/docs/how-to-guides/landscape-installation-and-setup/debarchive-repository-management.md) -->
 
 ### Create the first user
 

--- a/docs/how-to-guides/landscape-installation-and-set-up/quickstart-installation.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/quickstart-installation.md
@@ -9,6 +9,8 @@ myst:
 
 The quickstart mode of deploying Landscape consists of installing all the necessary software on a single machine. Quickstart mode has limited scalability, so it may not be ideal for large production deployments. 
 
+Note that Quickstart installations and upgrades to Landscape 26.04 LTS are not supported on Ubuntu 26.04. You must use Ubuntu 24.04 LTS or 22.04 LTS for Quickstart installations.
+
 If you're new to Landscape and want to learn how it works first, see the {ref}`getting-started-with-landscape` tutorial, which creates a test environment.
 
 ## Check minimum requirements
@@ -89,6 +91,38 @@ To install `landscape-server-quickstart`:
     ```
 
    - This installation takes approximately five minutes.
+
+
+### (26.04 only) Install the outbox snap
+
+Install the `landscape-outbox` snap on the same machine as your Landscape Server installation.
+
+```bash
+sudo snap install landscape-outbox
+```
+
+`landscape-outbox` is configured to work automatically with an existing Landscape Server by default. Confirm that the snap service is running.
+
+```bash
+sudo snap services landscape-outbox
+```
+
+The output should show the `outbox` service as **active**:
+
+```bash
+Service                  Startup  Current  Notes
+landscape-outbox.outbox  enabled  active   -
+```
+
+To view outbox logs, run:
+
+```bash
+sudo snap logs landscape-outbox -n 50
+```
+
+### (26.04 only) Install the debarchive snap
+
+<!-- TODO add when the release notes exist: The `landscape-debarchive` snap is required for repository management from Landscape 26.04 LTS onwards. Follow the instructions in the [dedicated guide](/docs/how-to-guides/landscape-installation-and-setup/debarchive-repository-management.md) -->
 
 ## Install an SSL certificate
 

--- a/docs/how-to-guides/landscape-installation-and-set-up/quickstart-installation.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/quickstart-installation.md
@@ -93,7 +93,7 @@ To install `landscape-server-quickstart`:
    - This installation takes approximately five minutes.
 
 
-### (26.04 only) Install the outbox snap
+### (Landscape 26.04 only) Install the outbox snap
 
 Install the `landscape-outbox` snap on the same machine as your Landscape Server installation.
 
@@ -120,7 +120,7 @@ To view outbox logs, run:
 sudo snap logs landscape-outbox -n 50
 ```
 
-### (26.04 only) Install the debarchive snap
+### (Landscape 26.04 only) Install the debarchive snap
 
 <!-- TODO add when the release notes exist: The `landscape-debarchive` snap is required for repository management from Landscape 26.04 LTS onwards. Follow the instructions in the [dedicated guide](/docs/how-to-guides/landscape-installation-and-setup/debarchive-repository-management.md) -->
 

--- a/docs/reference/_includes/landscape-ppas-table.md
+++ b/docs/reference/_includes/landscape-ppas-table.md
@@ -1,5 +1,5 @@
 | Release channel | PPA source to add | Support | Recommended for |
 |-----------------|-------------------|---------|-----------------|
 | LTS (versioned) | Pattern: `ppa:landscape/self-hosted-<VERSION>`<br>Example: `ppa:landscape/self-hosted-24.04` | 10 years; 5 point releases | Production |
-| Latest stable | `ppa:landscape/landscape-latest-stable` | Until next release (~6 months) | Production (must stay current) |
-| Beta | `ppa:landscape/landscape-beta` | None | Testing and development only |
+| Latest stable | `ppa:landscape/latest-stable` | Until next release (~6 months) | Production (must stay current) |
+| Beta | `ppa:landscape/self-hosted-beta` | None | Testing and development only |

--- a/docs/what-is-landscape.md
+++ b/docs/what-is-landscape.md
@@ -23,7 +23,7 @@ Although "Landscape" refers to both the Landscape Server and Landscape Client ap
 In addition, Landscape Server relies on the following third-party infrastructure:
 
 - **PostgreSQL**: The database.
-- **RabbitMQ**: Queues and processes background tasks, such as repository synchronisation supports internal communication between services (for example, triggering alerts).
+- **RabbitMQ**: Queues and processes background tasks, such as repository synchronisation. Supports internal communication between services (for example, triggering alerts).
 - (Usually) **HAProxy** or **Apache**: Handles HTTPS requests and routes them to Landscape Server. HAProxy is used for high-availability deployments.
 
 The Landscape message system (built into the Server) is responsible for communication between managed clients and the Server.


### PR DESCRIPTION
Duplicating some information from the upgrade guide to our install guides as per discussion with Yanisa. These docs should get some wording updates at the top to include 26.04 as an option, so there `(26.04)` parentheticals shouldn't be terribly out of place. I'd like to do verification of these instructions with the RCs before merging this, if possible.