### PR TITLE
fix: restore profiles refresh

### DIFF
--- a/docs/reference/terms/profiles.md
+++ b/docs/reference/terms/profiles.md
@@ -18,7 +18,14 @@ Landscape has multiple types of profiles.
 (reference-terms-package-profile)=
 ## Package profile
 
-A **package profile**, or meta-package, comprises a set of one or more packages, including their dependencies and conflicts (generally called constraints), that you can manage as a group. Package profiles specify sets of packages that associated systems should always get, or never get. You can associate zero or more computers with each package profile via tags to install packages on those computers. You can also associate a package profile with an access group, which limits its use to only computers within the specified access group. You can manage package profiles from the **Profiles** page.
+A **package profile**, or meta-package, comprises a set of one or more packages, including their dependencies and conflicts (generally called constraints), that you can manage as a group. Package profiles specify sets of packages that associated systems should always get, or never get.
+
+The constraints for package profiles can be specified in the following ways:
+- From an existing instance's packages
+- Imported from a CSV file
+- Manually specified
+
+Package profiles must be associated with an access group which determines the set of instances that the profile can act on. You can also associate zero or more managed instances with each package profile via tags. You can manage package profiles from the sidebar by navigating to **Profiles** > **Package Profiles**.
 
 Package profiles are evaluated periodically, and can be used for ensuring compliance over time. If package profiles are used to install packages, it is important to ensure any prerequisite repository configurations have been applied so the package can be downloaded, otherwise the package profile will fail to install the package, and report the machine as non-compliant.
 
@@ -29,7 +36,10 @@ A **reboot profile** defines how and when Landscape executes system reboots on m
 (reference-terms-removal-profile)=
 ## Removal profile
 
-A **removal profile** defines a maximum number of days that a computer can go without exchanging data with the Landscape server before it is automatically removed. If more days pass than the profile’s “Days without exchange”, that computer will automatically be removed and the license seat it held will be released. This helps Landscape keep license seats open and ensure Landscape is not tracking stale or retired computer data for long periods of time. You can associate zero or more computers with each removal profile via tags to ensure those computers are governed by this removal profile. You can also associate a removal profile with an access group, which limits its use to only computers within the specified access group. You can manage removal profiles from the **Profiles** page.
+A **removal profile** defines a maximum number of days that a managed instance can go without sending a message to Landscape server before it is automatically removed. If more days pass than the profile's *Days without exchange*, that managed instance will automatically be removed and the license seat it held will be released. This helps Landscape keep license seats open and ensures Landscape is not tracking stale or retired instance data for long periods of time. Landscape considers any message sent from the client to be data exchanged. Note that pings do not count as data exchanged, except for pings from Windows hosts.
+
+Removal profiles must be associated with an access group which determines the set of instances that the profile can act on. You can also associate zero or more managed instances with each removal profile via tags. You can manage removal profiles from the sidebar by navigating to **Profiles** > **Removal Profiles**.
+
 (reference-terms-repository-profile)=
 ## Repository profile
 
@@ -52,7 +62,11 @@ A **USG profile** defines how Landscape should monitor and manage security compl
 (reference-terms-upgrade-profile)=
 ## Upgrade profile
 
-An **upgrade profile** defines a schedule for the times when upgrades are to be automatically installed on the machines associated with a specific access group. You can associate zero or more computers with each upgrade profile via tags to install packages on those computers. You can also associate an upgrade profile with an access group, which limits its use to only computers within the specified access group. You can manage upgrade profiles from the **Profiles** page.
+An **upgrade profile** defines a schedule for the times when upgrades are to be automatically installed on the managed instances associated with a specific access group. You can also associate zero or more managed instances with each upgrade profile via tags.
+
+Upgrade profiles run according to a configurable weekly schedule. You can set what days of the week you want upgrades to run, and at what times you want upgrades to run on those days. You can also randomize the delivery time of the updates across your estate. Upgrade profiles can be set to only apply security upgrades or to apply all upgrades.
+
+You can manage upgrade profiles from the sidebar by navigating to **Profiles** > **Upgrade Profiles**.
 
 (reference-terms-wsl-profile)=
 ## WSL profile


### PR DESCRIPTION
The work from https://github.com/canonical/landscape-documentation/pull/188 got overwritten. This PR should be almost identical to the original.