### PR TITLE
add debarchive filesystem publication location to DISA STIG sample apache conf

### DIFF
--- a/docs/assets/disa-stig/landscape.conf
+++ b/docs/assets/disa-stig/landscape.conf
@@ -29,6 +29,7 @@
     Alias /offline /opt/canonical/landscape/canonical/landscape/offline
     Alias /static /opt/canonical/landscape/canonical/static
     Alias /repository /var/lib/landscape/landscape-repository
+    Alias /publications /var/snap/landscape-debarchive/common/publications
 
 
     <Location "/repository">
@@ -40,6 +41,18 @@
    <LocationMatch "/repository/[^/]+/[^/]+/(dists|pool)/.*">
      Allow from all
    </LocationMatch>
+
+    <Directory "/var/snap/landscape-debarchive/common/publications">
+      Options +Indexes
+      Order allow,deny
+      Allow from all
+      Require all granted
+    </Directory>
+
+    <Location "/publications">
+      Order allow,deny
+      Allow from all
+    </Location>
    <Location "/icons">
         Order allow,deny
         Allow from all
@@ -75,6 +88,7 @@
     RewriteCond %{REQUEST_URI} !^/static/
     RewriteCond %{REQUEST_URI} !^/offline/
     RewriteCond %{REQUEST_URI} !^/repository/
+    RewriteCond %{REQUEST_URI} !^/publications
     RewriteCond %{REQUEST_URI} !^/message-system
 
     # If you change the port number that Apache is providing SSL on, you must change the

--- a/docs/how-to-guides/landscape-installation-and-set-up/disa-stig.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/disa-stig.md
@@ -48,6 +48,8 @@ Every directory listed above must be configured in advance of installing Landsca
 
 If you are using Landscape Server for repository mirroring, packages will be downloaded to the `/var/lib/landscape/landscape-repository/` directory. Consider limiting the size of that directory based on the size of the pockets in each repository mirror.
 
+For Landscape 26.04 and later, repository files managed by the `landscape-debarchive` snap are stored in `/var/snap/landscape-debarchive/common`. If you are using this feature, consider also limiting the size of that directory.
+
 The method used to limit the size of these directories depends on the environment Landscape Server is deployed to.
 
 #### Deployment using LXD containers
@@ -965,6 +967,10 @@ Add the configuration file `/etc/apache2/sites-available/landscape.conf`. See th
 - `<KEYFILE>`: the full filesystem path to the private key corresponding to the SSL certificate. For example, `/etc/apache2/apache_server.key`
 - `<CA_CERTFILE>`: the full filesystem path to the DoD CA chain file for this server. For example, `/etc/ca-certificates.crt`
 - `<CRL_FILE>`: the full filesystem path to the DoD CRL file for revoked certificates. For example, `/etc/crl.crl`
+
+```{note}
+For Landscape 26.04 and later, the sample `landscape.conf` includes an additional `/publications` alias that serves files from `/var/snap/landscape-debarchive/common/publications` over HTTP, for use with the `landscape-debarchive` snap. The existing `/repository` alias is retained for backwards compatibility with older Landscape Server versions.
+```
 
 ### Set permissions for Apache2 files
 


### PR DESCRIPTION
This change updates the sample DISA STIG apache configuration file to include a `/publications` HTTP endpoint, serving the default location of filesystem publications for debarchive: `/var/snap/landscape-debarchive/common/publications`. I've tested this on a local installation:

```
$ curl http://10.149.172.216/publications/dists/jammy-backports/Release | head -n20

Label: Ubuntu
Suite: jammy-backports
Version: 22.04
Codename: jammy
Date: Tue, 26 May 2026 12:50:17 UTC
Architectures: amd64 arm64 armhf i386 ppc64el riscv64 s390x
Components: main restricted universe multiverse
Description: Ubuntu Jammy Backports
NotAutomatic: yes
ButAutomaticUpgrades: yes
MD5Sum:
 72718ce07960ce4fdc88f6a3b9e34b4b         14215034 Contents-amd64
 51eafbc97498dd0ab289e6b22ff451af           794935 Contents-amd64.gz
 4a3c722e34c8360df5ec1549da49fee1         14202665 Contents-arm64
 b8c6cbf27af34254b2f6f7446a750ed9           793447 Contents-arm64.gz
 f1402eaa1970d6d00f49070db443e232         14213358 Contents-armhf
 4ea9fc480e65e715bfc5b33095e06fd3           793972 Contents-armhf.gz
 5d70720efa5097fefac9939e5692f5ef         14125765 Contents-i386
 57c1c6aad83ae9c9c1891bff27d7fe39           785794 Contents-i386.gz
 34  123k   34 43193    0     0  21.4M      0 --:--:-- --:--:-- --:--:-- 41.1M

```

It also updates wording in the guide to make reference to this change.