### PR TITLE
chore: update openapi.yaml from landscape-proto

### DIFF
--- a/docs/_static/openapi.yaml
+++ b/docs/_static/openapi.yaml
@@ -1,0 +1,1684 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: debarchive
+    version: 0.1.0
+paths:
+    /v1beta1/locals:
+        get:
+            tags:
+                - LocalService
+            description: ListLocals returns a list of Locals.
+            operationId: LocalService_ListLocals
+            parameters:
+                - name: pageSize
+                  in: query
+                  description: |-
+                    The maximum number of local repositories to return.
+                     The service may return fewer than this value.
+                     If unspecified, at most 100 local repositories will be returned.
+                     The maximum value is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: |-
+                    A page token, received from a previous `ListLocals` call.
+                     Provide this to retrieve the subsequent page.
+
+                     When paginating, all other parameters provided to `ListLocals` must match
+                     the call that provided the page token.
+                  schema:
+                    type: string
+                - name: filter
+                  in: query
+                  description: |-
+                    An expression for filtering the results of the request.
+                     The fields eligible for filtering are:
+
+                       * `display_name`
+
+                     Some examples of using filters are:
+
+                       * `display_name="local"`  --> The local has the display name "local".
+                       * `display_name="local*"` --> The local has the prefix "local" in its display name.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListLocalsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - LocalService
+            description: CreateLocal creates a new Local repository.
+            operationId: LocalService_CreateLocal
+            parameters:
+                - name: localId
+                  in: query
+                  description: |-
+                    The ID to use for the local repository (optional).
+                     If provided, the full resource name will be `locals/{local_id}`.
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Local'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Local'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/locals/{local}:
+        get:
+            tags:
+                - LocalService
+            description: GetLocal retrieves a Local by its resource name.
+            operationId: LocalService_GetLocal
+            parameters:
+                - name: local
+                  in: path
+                  description: The local id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Local'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - LocalService
+            description: DeleteLocal deletes a Local.
+            operationId: LocalService_DeleteLocal
+            parameters:
+                - name: local
+                  in: path
+                  description: The local id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        patch:
+            tags:
+                - LocalService
+            description: UpdateLocal updates the details of a Local.
+            operationId: LocalService_UpdateLocal
+            parameters:
+                - name: local
+                  in: path
+                  description: The local id.
+                  required: true
+                  schema:
+                    type: string
+                - name: updateMask
+                  in: query
+                  description: The list of fields to update.
+                  schema:
+                    type: string
+                    format: field-mask
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Local'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Local'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/locals/{local}/packages:
+        get:
+            tags:
+                - LocalService
+            description: ListLocalPackages retrieves a list of packages available in the Local.
+            operationId: LocalService_ListLocalPackages
+            parameters:
+                - name: local
+                  in: path
+                  description: The local id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: |-
+                    The maximum number of packages to return.
+                     The service may return fewer than this value.
+                     If unspecified, at most 100 packages will be returned.
+                     The maximum value is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: |-
+                    A page token, received from a previous `ListLocalPackages` call.
+                     Provide this to retrieve the subsequent page.
+
+                     When paginating, all other parameters provided to `ListLocalPackages` must match
+                     the call that provided the page token.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListLocalPackagesResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/locals/{local}:importPackages:
+        post:
+            tags:
+                - LocalService
+            description: |-
+                ImportLocalPackages imports packages from a URL pointing to a package list or index
+                 into the Local. This is an async operation; poll the returned Operation for status.
+                 (-- api-linter: core::0136::response-message-name=disabled
+                     aip.dev/not-precedent: We need to do this because the linter expects
+                     LRO responses to use the format of `ImportLocalPackagesResponse` but we are using
+                     a generic response for any task that is created using aptly. --)
+            operationId: LocalService_ImportLocalPackages
+            parameters:
+                - name: local
+                  in: path
+                  description: The local id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ImportLocalPackagesRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Operation'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/locals:batchGet:
+        post:
+            tags:
+                - LocalService
+            description: BatchGetLocals retrieves a list of locals based on their name.
+            operationId: LocalService_BatchGetLocals
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/BatchGetLocalsRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/BatchGetLocalsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/mirrors:
+        get:
+            tags:
+                - MirrorService
+            description: ListMirrors returns a list of Mirrors.
+            operationId: MirrorService_ListMirrors
+            parameters:
+                - name: pageSize
+                  in: query
+                  description: |-
+                    The maximum number of mirrors to return.
+                     The service may return fewer than this value.
+                     If unspecified, at most 100 mirrors will be returned.
+                     The maximum value is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: |-
+                    A page token, received from a previous `ListMirrors` call.
+                     Provide this to retrieve the subsequent page.
+
+                     When paginating, all other parameters provided to `ListMirrors` must match
+                     the call that provided the page token.
+                  schema:
+                    type: string
+                - name: filter
+                  in: query
+                  description: |-
+                    An expression for filtering the results of the request.
+                     The fields eligible for filtering are:
+
+                       * `display_name`
+
+                     Some examples of using filters are:
+
+                       * `display_name="mirror"`  --> The mirror has the display name "mirror".
+                       * `display_name="mirror*"` --> The mirror has the prefix "mirror" in its display name.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListMirrorsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - MirrorService
+            description: |-
+                CreateMirror creates a new Mirror.
+                 It validates the upstream but does not initiate synchronization.
+            operationId: MirrorService_CreateMirror
+            parameters:
+                - name: mirrorId
+                  in: query
+                  description: |-
+                    The ID to use for the mirror (optional).
+                     If provided, the full resource name will be `mirrors/{mirror_id}`.
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Mirror'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Mirror'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/mirrors/{mirror}:
+        get:
+            tags:
+                - MirrorService
+            description: GetMirror retrieves a Mirror by its resource name.
+            operationId: MirrorService_GetMirror
+            parameters:
+                - name: mirror
+                  in: path
+                  description: The mirror id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Mirror'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - MirrorService
+            description: DeleteMirror deletes a Mirror.
+            operationId: MirrorService_DeleteMirror
+            parameters:
+                - name: mirror
+                  in: path
+                  description: The mirror id.
+                  required: true
+                  schema:
+                    type: string
+                - name: force
+                  in: query
+                  description: Flag for if you want to force delete the mirror
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        patch:
+            tags:
+                - MirrorService
+            description: UpdateMirror updates the details of a Mirror.
+            operationId: MirrorService_UpdateMirror
+            parameters:
+                - name: mirror
+                  in: path
+                  description: The mirror id.
+                  required: true
+                  schema:
+                    type: string
+                - name: updateMask
+                  in: query
+                  description: The list of fields to update.
+                  schema:
+                    type: string
+                    format: field-mask
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Mirror'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Mirror'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/mirrors/{mirror}/packages:
+        get:
+            tags:
+                - MirrorService
+            description: ListMirrorPackages retrieves a list of packages available in the Mirror.
+            operationId: MirrorService_ListMirrorPackages
+            parameters:
+                - name: mirror
+                  in: path
+                  description: The mirror id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: |-
+                    The maximum number of packages to return.
+                     The service may return fewer than this value.
+                     If unspecified, at most 100 packages will be returned.
+                     The maximum value is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: |-
+                    A page token, received from a previous `ListMirrorPackages` call.
+                     Provide this to retrieve the subsequent page.
+
+                     When paginating, all other parameters provided to `ListMirrorPackages` must match
+                     the call that provided the page token.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListMirrorPackagesResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/mirrors/{mirror}:sync:
+        post:
+            tags:
+                - MirrorService
+            description: |-
+                SyncMirror synchronizes a Mirror.
+                 (-- api-linter: core::0136::response-message-name=disabled
+                     aip.dev/not-precedent: We need to do this because the linter expects
+                     LRO responses to use the format of `SyncMirrorResponse` but we are using
+                     a generic response for any task that is created using aptly. --)
+            operationId: MirrorService_SyncMirror
+            parameters:
+                - name: mirror
+                  in: path
+                  description: The mirror id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/SyncMirrorRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Operation'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/mirrors:batchGet:
+        post:
+            tags:
+                - MirrorService
+            description: BatchGetMirrors retrieves a list of mirrors based on their name.
+            operationId: MirrorService_BatchGetMirrors
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/BatchGetMirrorsRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/BatchGetMirrorsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/operations/{operation}:
+        get:
+            tags:
+                - OperationService
+            description: |-
+                Gets the latest state of a long-running operation.  Clients can use this
+                 method to poll the operation result at intervals as recommended by the API
+                 service.
+            operationId: OperationService_GetOperation
+            parameters:
+                - name: operation
+                  in: path
+                  description: The operation id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Operation'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/publicationTargets:
+        get:
+            tags:
+                - PublicationTargetService
+            description: ListPublicationTargets lists all PublicationTargets.
+            operationId: PublicationTargetService_ListPublicationTargets
+            parameters:
+                - name: pageSize
+                  in: query
+                  description: |-
+                    The maximum number of publication targets to return.
+                     The service may return fewer than this value.
+                     If unspecified, at most 100 publication targets will be returned.
+                     The maximum value is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: |-
+                    A page token, received from a previous `ListPublicationTargets` call.
+                     Provide this to retrieve the subsequent page.
+
+                     When paginating, all other parameters provided to `ListPublicationTargets` must match
+                     the call that provided the page token.
+                  schema:
+                    type: string
+                - name: filter
+                  in: query
+                  description: |-
+                    An expression for filtering the results of the request.
+                     The fields eligible for filtering are:
+
+                       * `display_name`
+
+                     Some examples of using filters are:
+
+                       * `display_name="target"`  --> The publication target has the display name "target".
+                       * `display_name="target*"` --> The publication target has the prefix "target" in its display name.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListPublicationTargetsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - PublicationTargetService
+            description: CreatePublicationTarget creates a new PublicationTarget.
+            operationId: PublicationTargetService_CreatePublicationTarget
+            parameters:
+                - name: publicationTargetId
+                  in: query
+                  description: |-
+                    The ID to use for the publication target (optional).
+                     If not provided, the server will generate one.
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/PublicationTarget'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/PublicationTarget'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/publicationTargets/{publicationTarget}:
+        get:
+            tags:
+                - PublicationTargetService
+            description: GetPublicationTarget gets details of a single PublicationTarget.
+            operationId: PublicationTargetService_GetPublicationTarget
+            parameters:
+                - name: publicationTarget
+                  in: path
+                  description: The publicationTarget id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/PublicationTarget'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - PublicationTargetService
+            description: DeletePublicationTarget deletes a PublicationTarget.
+            operationId: PublicationTargetService_DeletePublicationTarget
+            parameters:
+                - name: publicationTarget
+                  in: path
+                  description: The publicationTarget id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        patch:
+            tags:
+                - PublicationTargetService
+            description: UpdatePublicationTarget replaces (full replacement) an existing PublicationTarget.
+            operationId: PublicationTargetService_UpdatePublicationTarget
+            parameters:
+                - name: publicationTarget
+                  in: path
+                  description: The publicationTarget id.
+                  required: true
+                  schema:
+                    type: string
+                - name: updateMask
+                  in: query
+                  description: The list of fields to update.
+                  schema:
+                    type: string
+                    format: field-mask
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/PublicationTarget'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/PublicationTarget'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/publicationTargets:batchGet:
+        post:
+            tags:
+                - PublicationTargetService
+            description: BatchGetPublicationTargets retrieves a list of publication targets based on their name.
+            operationId: PublicationTargetService_BatchGetPublicationTargets
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/BatchGetPublicationTargetsRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/BatchGetPublicationTargetsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/publications:
+        get:
+            tags:
+                - PublicationService
+            description: ListPublications returns a list of Publications.
+            operationId: PublicationService_ListPublications
+            parameters:
+                - name: pageSize
+                  in: query
+                  description: |-
+                    The maximum number of publications to return.
+                     The service may return fewer than this value.
+                     If unspecified, at most 100 publications will be returned.
+                     The maximum value is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: |-
+                    A page token, received from a previous `ListPublication` call.
+                     Provide this to retrieve the subsequent page.
+
+                     When paginating, all other parameters provided to `ListPublication` must match
+                     the call that provided the page token.
+                  schema:
+                    type: string
+                - name: filter
+                  in: query
+                  description: |-
+                    An expression for filtering the results of the request.
+                     The fields eligible for filtering are:
+
+                       * `source`
+                       * `publication_target`
+
+                     Some examples of using filters are:
+
+                       * `source="locals/123"`  --> The publication has source "locals/123".
+                       * `publication_target="publicationTargets/456"` --> The publication has target "publicationTargets/456".
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListPublicationsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - PublicationService
+            description: CreatePublication creates a new Publication.
+            operationId: PublicationService_CreatePublication
+            parameters:
+                - name: publicationId
+                  in: query
+                  description: The ID to use for the publication (optional).
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Publication'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Publication'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/publications/{publication}:
+        get:
+            tags:
+                - PublicationService
+            description: GetPublication retrieves a Publication by its resource name.
+            operationId: PublicationService_GetPublication
+            parameters:
+                - name: publication
+                  in: path
+                  description: The publication id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Publication'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - PublicationService
+            description: |-
+                DeletePublication deletes a Publication.
+                 Note: This operation may trigger a background Task to clean up published artifacts.
+            operationId: PublicationService_DeletePublication
+            parameters:
+                - name: publication
+                  in: path
+                  description: The publication id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        patch:
+            tags:
+                - PublicationService
+            description: UpdatePublication updates the details of a Publication.
+            operationId: PublicationService_UpdatePublication
+            parameters:
+                - name: publication
+                  in: path
+                  description: The publication id.
+                  required: true
+                  schema:
+                    type: string
+                - name: updateMask
+                  in: query
+                  description: The list of fields to update.
+                  schema:
+                    type: string
+                    format: field-mask
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Publication'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Publication'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1beta1/publications/{publication}:publish:
+        post:
+            tags:
+                - PublicationService
+            description: |-
+                PublishPublication triggers the actual publication process.
+                 This is a custom method that returns a background Task.
+                 (-- api-linter: core::0136::response-message-name=disabled
+                     aip.dev/not-precedent: We need to do this because the linter expects
+                     LRO responses to use the format of `PublishPublicationResponse` but we
+                     are using a generic response for any task that is created using aptly. --)
+            operationId: PublicationService_PublishPublication
+            parameters:
+                - name: publication
+                  in: path
+                  description: The publication id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/PublishPublicationRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Operation'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        BatchGetLocalsRequest:
+            required:
+                - names
+            type: object
+            properties:
+                names:
+                    type: array
+                    items:
+                        type: string
+                    description: |-
+                        The names of the locals to retrieve.
+                         A maximum of 100 locals can be retrieved in a batch.
+                         Format: locals/{local}
+            description: BatchGetLocalsRequest is the request message for BatchGetLocals
+        BatchGetLocalsResponse:
+            type: object
+            properties:
+                locals:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Local'
+                    description: Locals requested.
+            description: BatchGetLocalsResponse is the response message for BatchGetLocals
+        BatchGetMirrorsRequest:
+            required:
+                - names
+            type: object
+            properties:
+                names:
+                    type: array
+                    items:
+                        type: string
+                    description: |-
+                        The names of the mirrors to retrieve.
+                         A maximum of 100 mirrors can be retrieved in a batch.
+                         Format: mirrors/{mirror}
+            description: BatchGetMirrorsRequest is the request message for BatchGetMirrors
+        BatchGetMirrorsResponse:
+            type: object
+            properties:
+                mirrors:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Mirror'
+                    description: Mirrors requested.
+            description: BatchGetMirrorsResponse is the response message for BatchGetMirrors
+        BatchGetPublicationTargetsRequest:
+            required:
+                - names
+            type: object
+            properties:
+                names:
+                    type: array
+                    items:
+                        type: string
+                    description: |-
+                        The names of the publication targets to retrieve.
+                         A maximum of 100 publication targets can be retrieved in a batch.
+                         Format: publicationTargets/{publication_target}
+            description: BatchGetPublicationTargetsRequest is the request message for BatchGetPublicationTargets
+        BatchGetPublicationTargetsResponse:
+            type: object
+            properties:
+                publicationTargets:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/PublicationTarget'
+                    description: Publication targets requested.
+            description: BatchGetPublicationTargetsResponse is the response message for BatchGetPublicationTargets
+        FilesystemTarget:
+            required:
+                - path
+            type: object
+            properties:
+                path:
+                    type: string
+                    description: The absolute path to the directory where files should be published.
+                linkMethod:
+                    enum:
+                        - HARDLINK
+                        - SYMLINK
+                        - COPY
+                    type: string
+                    description: The link method to use for published files.
+                    format: enum
+            description: FilesystemTarget represents a local filesystem storage destination.
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        GpgKey:
+            required:
+                - armor
+            type: object
+            properties:
+                armor:
+                    writeOnly: true
+                    type: string
+                    description: The GPG key in ASCII armor format.
+                isPrivate:
+                    readOnly: true
+                    type: boolean
+                    description: Indicates if the key holds a private component.
+                fingerprint:
+                    readOnly: true
+                    type: string
+                    description: The fingerprint of the key.
+            description: GpgKey represents a gpg key.
+        ImportLocalPackagesRequest:
+            required:
+                - name
+                - url
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |-
+                        The resource name of the local repository to import packages into.
+                         Format: "locals/{local}"
+                url:
+                    type: string
+                    description: The URL of the package list or index to import from.
+                validateOnly:
+                    type: boolean
+                    description: |-
+                        If set to true, the request is validated without actually performing the import.
+                         The set of packages that would be imported is returned as the result of the task.
+                         See: https://google.aip.dev/163
+            description: ImportLocalPackagesRequest is the request message for ImportLocalPackages.
+        ListLocalPackagesResponse:
+            type: object
+            properties:
+                localPackages:
+                    type: array
+                    items:
+                        type: string
+                    description: |-
+                        The list of package strings.
+                         Example: ["snap-http_1.4.0_source", ...]
+                nextPageToken:
+                    type: string
+                    description: |-
+                        A token, which can be sent as `page_token` to retrieve the next page.
+                         If this field is omitted, there are no subsequent pages.
+            description: ListLocalPackagesResponse is the response message for ListLocalPackages.
+        ListLocalsResponse:
+            type: object
+            properties:
+                locals:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Local'
+                    description: The list of local repositories.
+                nextPageToken:
+                    type: string
+                    description: |-
+                        A token, which can be sent as `page_token` to retrieve the next page.
+                         If this field is omitted, there are no subsequent pages.
+            description: ListLocalsResponse is the response message for ListLocals.
+        ListMirrorPackagesResponse:
+            type: object
+            properties:
+                mirrorPackages:
+                    type: array
+                    items:
+                        type: string
+                    description: |-
+                        The list of package strings.
+                         Example: ["snap-http_1.4.0_source", ...]
+                nextPageToken:
+                    type: string
+                    description: |-
+                        A token, which can be sent as `page_token` to retrieve the next page.
+                         If this field is omitted, there are no subsequent pages.
+            description: ListMirrorPackagesResponse is the response message for ListMirrorPackages.
+        ListMirrorsResponse:
+            type: object
+            properties:
+                mirrors:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Mirror'
+                    description: The list of mirrors.
+                nextPageToken:
+                    type: string
+                    description: |-
+                        A token, which can be sent as `page_token` to retrieve the next page.
+                         If this field is omitted, there are no subsequent pages.
+            description: ListMirrorsResponse is the response message for ListMirrors.
+        ListPublicationTargetsResponse:
+            type: object
+            properties:
+                publicationTargets:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/PublicationTarget'
+                    description: The publication targets.
+                nextPageToken:
+                    type: string
+                    description: |-
+                        A token, which can be sent as `page_token` to retrieve the next page.
+                         If this field is omitted, there are no subsequent pages.
+            description: ListPublicationTargetsResponse is the response message for ListPublicationTargets.
+        ListPublicationsResponse:
+            type: object
+            properties:
+                publications:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Publication'
+                    description: A list of publications.
+                nextPageToken:
+                    type: string
+                    description: |-
+                        A token, which can be sent as `page_token` to retrieve the next page.
+                         If this field is omitted, there are no subsequent pages.
+            description: ListPublicationsResponse is the response message for ListPublications.
+        Local:
+            required:
+                - displayName
+                - defaultComponent
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |-
+                        The resource name of the local repository.
+                         Format: "locals/{local}"
+                localId:
+                    readOnly: true
+                    type: string
+                    description: The local repository ID is exposed separately for convenience.
+                displayName:
+                    type: string
+                    description: The human-readable name used to reference this local repository.
+                comment:
+                    type: string
+                    description: A user-facing description of the local repository.
+                defaultDistribution:
+                    type: string
+                    description: The default distribution to publish.
+                defaultComponent:
+                    type: string
+                    description: The default component to publish.
+                lastOperation:
+                    readOnly: true
+                    type: string
+                    description: The last associated LRO with the local
+            description: Local represents a local repository configuration.
+        Mirror:
+            required:
+                - displayName
+                - archiveRoot
+                - components
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |-
+                        The resource name of the mirror.
+                         Format: "mirrors/{mirror}"
+                mirrorId:
+                    readOnly: true
+                    type: string
+                    description: The mirror ID is exposed separately for convenience.
+                status:
+                    readOnly: true
+                    type: string
+                    description: The status of the mirror.
+                lastDownloadDate:
+                    readOnly: true
+                    type: string
+                    description: The timestamp of the last successful download.
+                    format: date-time
+                displayName:
+                    type: string
+                    description: The human-readable name used to reference this mirror.
+                archiveRoot:
+                    type: string
+                    description: Root of the debian archive (URL).
+                distribution:
+                    type: string
+                    description: The name of the distribution (subdirectory of `dists`).
+                architectures:
+                    type: array
+                    items:
+                        type: string
+                    description: List of architectures to fetch.
+                components:
+                    type: array
+                    items:
+                        type: string
+                    description: List of components to fetch.
+                downloadInstaller:
+                    type: boolean
+                    description: Indicates if installer files should be downloaded.
+                downloadSources:
+                    type: boolean
+                    description: Indicates if sources files should be downloaded.
+                downloadUdebs:
+                    type: boolean
+                    description: Indicates if `.udebs` files should be downloaded.
+                filter:
+                    type: string
+                    description: |-
+                        Package query applied to the mirror.
+                         Follows the [Reprepro/Aptly language](https://www.aptly.info/doc/feature/query/).
+                filterWithDeps:
+                    type: boolean
+                    description: Indicates if dependencies of matching packages should be included.
+                skipArchitectureCheck:
+                    type: boolean
+                    description: Indicates if the architecture list verification should be skipped.
+                skipComponentCheck:
+                    type: boolean
+                    description: Indicates if the component list verification should be skipped.
+                preserveSignatures:
+                    type: boolean
+                    description: Indicates if the mirror is a signature-preserving mirror.
+                gpgKey:
+                    allOf:
+                        - $ref: '#/components/schemas/GpgKey'
+                    description: Optional GPG key to validate the upstream signature.
+                lastOperation:
+                    readOnly: true
+                    type: string
+                    description: The last associated LRO with the mirror
+            description: Mirror represents a repository mirror configuration and status.
+        Operation:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |-
+                        The server-assigned name, which is only unique within the same service that
+                         originally returns it. If you use the default HTTP mapping, the
+                         `name` should be a resource name ending with `operations/{unique_id}`.
+                metadata:
+                    allOf:
+                        - $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: |-
+                        Service-specific metadata associated with the operation.  It typically
+                         contains progress information and common metadata such as create time.
+                         Some services might not provide such metadata.  Any method that returns a
+                         long-running operation should document the metadata type, if any.
+                done:
+                    type: boolean
+                    description: |-
+                        If the value is `false`, it means the operation is still in progress.
+                         If `true`, the operation is completed, and either `error` or `response` is
+                         available.
+                error:
+                    allOf:
+                        - $ref: '#/components/schemas/Status'
+                    description: The error result of the operation in case of failure or cancellation.
+                response:
+                    allOf:
+                        - $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: |-
+                        The normal, successful response of the operation.  If the original
+                         method returns no data on success, such as `Delete`, the response is
+                         `google.protobuf.Empty`.  If the original method is standard
+                         `Get`/`Create`/`Update`, the response should be the resource.  For other
+                         methods, the response should have the type `XxxResponse`, where `Xxx`
+                         is the original method name.  For example, if the original method name
+                         is `TakeSnapshot()`, the inferred response type is
+                         `TakeSnapshotResponse`.
+            description: |-
+                This resource represents a long-running operation that is the result of a
+                 network API call.
+        Publication:
+            required:
+                - displayName
+                - publicationTarget
+                - source
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |-
+                        The resource name of the publication.
+                         Format: "publications/{uuid}"
+                displayName:
+                    type: string
+                    description: The human-readable name used to reference this publication.
+                publicationId:
+                    readOnly: true
+                    type: string
+                    description: The publication ID (UUID) is exposed separately for convenience.
+                publicationTarget:
+                    type: string
+                    description: |-
+                        The resource name of the publication target.
+                         Format: "publicationTargets/{publication_target}"
+                source:
+                    type: string
+                    description: |-
+                        The resource name of the source mirror or local.
+                         Format: "mirrors/{mirror}" or "locals/{local}"
+                distribution:
+                    type: string
+                    description: |-
+                        The name of the distribution.
+                         Inferred from the source if omitted.
+                label:
+                    type: string
+                    description: Value for the `Label:` field in the Release file.
+                origin:
+                    type: string
+                    description: |-
+                        Value for the `Origin:` field in the Release file.
+                         Inferred from the source if omitted.
+                architectures:
+                    type: array
+                    items:
+                        type: string
+                    description: |-
+                        List of architectures to publish.
+                         Defaults to all source architectures if omitted.
+                acquireByHash:
+                    type: boolean
+                    description: Provides index file by hash if unique.
+                butAutomaticUpgrades:
+                    type: boolean
+                    description: 'Sets `ButAutomaticUpgrade: yes|no` in the Release file if provided.'
+                notAutomatic:
+                    type: boolean
+                    description: 'Sets `NotAutomatic: yes|no` in the Release file if provided.'
+                multiDist:
+                    type: boolean
+                    description: Indicates if multiple distributions are supported.
+                skipBz2:
+                    type: boolean
+                    description: Indicates if bz2 compression should be skipped for index files.
+                skipContents:
+                    type: boolean
+                    description: Indicates if content indexes should not be generated.
+                gpgKey:
+                    allOf:
+                        - $ref: '#/components/schemas/GpgKey'
+                    description: Optional GPG key to sign the release file(s).
+                publishTime:
+                    readOnly: true
+                    type: string
+                    description: The timestamp of the last successful publication.
+                    format: date-time
+                lastOperation:
+                    readOnly: true
+                    type: string
+                    description: The last associated LRO with the publication
+            description: |-
+                Publication represents the configuration for publishing Debian artifacts
+                 from a Source (Mirror or Local) to a Target.
+        PublicationTarget:
+            required:
+                - displayName
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |-
+                        The resource name of the publication target.
+                         Format: "publicationTargets/{publication_target}"
+                displayName:
+                    type: string
+                    description: The user-defined display name.
+                publicationTargetId:
+                    readOnly: true
+                    type: string
+                    description: The publication_id (uuid) is part of the `name`, and is exposed separately for convenience.
+                s3:
+                    allOf:
+                        - $ref: '#/components/schemas/S3Target'
+                    description: The S3 storage.
+                swift:
+                    allOf:
+                        - $ref: '#/components/schemas/SwiftTarget'
+                    description: The Swift storage.
+                filesystem:
+                    allOf:
+                        - $ref: '#/components/schemas/FilesystemTarget'
+                    description: The Filesystem storage.
+            description: PublicationTarget represents a storage destination (currently supports S3 or Swift).
+        PublishPublicationRequest:
+            required:
+                - name
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |-
+                        The resource name of the publication to publish.
+                         Format: "publications/{publication}"
+                forceOverwrite:
+                    type: boolean
+                    description: Force overwrite of existing artifacts.
+                forceCleanup:
+                    type: boolean
+                    description: Force cleanup of old artifacts.
+            description: PublishPublicationRequest is the request message for PublishPublication.
+        S3Target:
+            required:
+                - region
+                - bucket
+                - awsAccessKeyId
+                - awsSecretAccessKey
+            type: object
+            properties:
+                region:
+                    type: string
+                    description: The AWS region for the S3 bucket.
+                bucket:
+                    type: string
+                    description: The name of the S3 bucket.
+                endpoint:
+                    type: string
+                    description: |-
+                        Hostname used for S3 compatible storage.
+                         If set, the region is ignored.
+                awsAccessKeyId:
+                    writeOnly: true
+                    type: string
+                    description: AWS credentials (Access Key ID) to access the S3 bucket.
+                awsSecretAccessKey:
+                    writeOnly: true
+                    type: string
+                    description: AWS credentials (Secret Access Key) to access the S3 bucket.
+                prefix:
+                    type: string
+                    description: |-
+                        Prefix used in the bucket.
+                         Defaults to the bucket root if not specified.
+                acl:
+                    type: string
+                    description: ACL (Access Control List) used for published files.
+                storageClass:
+                    type: string
+                    description: The AWS S3 storage class to use.
+                encryptionMethod:
+                    type: string
+                    description: |-
+                        Server-side encryption method. Defaults to none.
+                         Currently, the only available encryption method is `AES256`.
+                plusWorkaround:
+                    type: boolean
+                    description: Workaround for specific S3-compatible issues (e.g. "+" in filenames).
+                disableMultiDel:
+                    type: boolean
+                    description: |-
+                        Disables the `MultiDel` S3 API.
+                         Useful for S3-compatible cloud storage providers that do not support it.
+                forceSigV2:
+                    type: boolean
+                    description: |-
+                        Disables Signature V4 support.
+                         Useful for S3-compatible cloud storage providers that do not support SigV4.
+                debug:
+                    type: boolean
+                    description: Enables debug logging for S3 operations.
+            description: S3Target represents an S3 storage destination.
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+        SwiftTarget:
+            required:
+                - container
+                - username
+                - password
+                - authUrl
+            type: object
+            properties:
+                container:
+                    type: string
+                    description: The name of the container.
+                username:
+                    writeOnly: true
+                    type: string
+                    description: OpenStack credentials (Username) to access Keystone.
+                password:
+                    writeOnly: true
+                    type: string
+                    description: OpenStack credentials (Password) to access Keystone.
+                prefix:
+                    type: string
+                    description: |-
+                        Prefix used in the container.
+                         Defaults to the container root if not specified.
+                authUrl:
+                    type: string
+                    description: The full URL of the Keystone server (including port and version).
+                tenant:
+                    type: string
+                    description: The OpenStack tenant name.
+                tenantId:
+                    type: string
+                    description: The OpenStack tenant ID.
+                domain:
+                    type: string
+                    description: The OpenStack domain name.
+                domainId:
+                    type: string
+                    description: The OpenStack domain ID.
+                tenantDomain:
+                    type: string
+                    description: The OpenStack domain name the tenant/project belongs to.
+                tenantDomainId:
+                    type: string
+                    description: The OpenStack domain ID the tenant/project belongs to.
+            description: SwiftTarget represents a Swift (OpenStack) storage destination.
+        SyncMirrorRequest:
+            required:
+                - name
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |-
+                        The resource name of the mirror to sync.
+                         Format: "mirrors/{mirror}"
+                keyrings:
+                    type: array
+                    items:
+                        type: string
+                    description: Optional keyring files to use for validation.
+                ignoreChecksums:
+                    type: boolean
+                    description: Ignore checksum mismatches.
+                ignoreSignatures:
+                    type: boolean
+                    description: Ignore signature verification failures.
+                forceUpdate:
+                    type: boolean
+                    description: Force a full update.
+                skipExistingPackages:
+                    type: boolean
+                    description: Skip downloading packages that already exist.
+            description: SyncMirrorRequest is the request message for SyncMirror.
+tags:
+    - name: LocalService
+      description: LocalService manages local repositories.
+    - name: MirrorService
+      description: MirrorService manages repository mirrors.
+    - name: OperationService
+      description: |-
+        Copies google's long running operations Service. While generally not supposed to
+         define our own interfaces to prevent non-uniformity, this is necessary for practical reasons.
+         OpenAPI stubs are generated for FE with this, it allows for simpler means of updating the path
+         for gateways, and overall makes it more practical for development. It also does not introduce
+         non-uniformity as it is directly copy-pasted as is and changes nothing.
+         Source: https://github.com/googleapis/googleapis/blob/master/google/longrunning/operations.proto
+    - name: PublicationService
+      description: PublicationService manages the publication of Debian artifacts.
+    - name: PublicationTargetService
+      description: PublicationTargetService manages the storage destinations for Debian archives.
+
+      


### PR DESCRIPTION
Automated update of `docs/_static/openapi.yaml` from [landscape-proto](https://github.com/canonical/landscape-proto).

Triggered by push to main: 1efc1dad578e294ecd5bda590cb026cbfea71a87