### PR TITLE
Apache samples serve debarchive repos on port 443

### DIFF
--- a/docs/assets/disa-stig/landscape.conf
+++ b/docs/assets/disa-stig/landscape.conf
@@ -29,7 +29,6 @@
     Alias /offline /opt/canonical/landscape/canonical/landscape/offline
     Alias /static /opt/canonical/landscape/canonical/static
     Alias /repository /var/lib/landscape/landscape-repository
-    Alias /publications /var/snap/landscape-debarchive/common/publications
 
 
     <Location "/repository">
@@ -42,17 +41,6 @@
      Allow from all
    </LocationMatch>
 
-    <Directory "/var/snap/landscape-debarchive/common/publications">
-      Options +Indexes
-      Order allow,deny
-      Allow from all
-      Require all granted
-    </Directory>
-
-    <Location "/publications">
-      Order allow,deny
-      Allow from all
-    </Location>
    <Location "/icons">
         Order allow,deny
         Allow from all
@@ -88,7 +76,6 @@
     RewriteCond %{REQUEST_URI} !^/static/
     RewriteCond %{REQUEST_URI} !^/offline/
     RewriteCond %{REQUEST_URI} !^/repository/
-    RewriteCond %{REQUEST_URI} !^/publications
     RewriteCond %{REQUEST_URI} !^/message-system
 
     # If you change the port number that Apache is providing SSL on, you must change the
@@ -137,9 +124,22 @@
       Allow from all
     </Location>
 
+    <Directory "/var/snap/landscape-debarchive/common/publications">
+      Options +Indexes
+      Order allow,deny
+      Allow from all
+      Require all granted
+    </Directory>
+
+    <Location "/publications">
+      Order allow,deny
+      Allow from all
+    </Location>
+
     Alias /offline /opt/canonical/landscape/canonical/landscape/offline
     Alias /config /opt/canonical/landscape/apacheroot
     Alias /hash-id-databases /var/lib/landscape/hash-id-databases
+    Alias /publications /var/snap/landscape-debarchive/common/publications
 
     ProxyRequests off
     <Proxy *>
@@ -195,6 +195,7 @@
     RewriteCond %{REQUEST_URI} !^/(r/[^/]+/)?static/
     RewriteCond %{REQUEST_URI} !^/config/
     RewriteCond %{REQUEST_URI} !^/hash-id-databases/
+    RewriteCond %{REQUEST_URI} !^/publications
 
     # If you change the port number that Apache is providing SSL on, you must change the
     # port number 443 here.

--- a/docs/assets/disa-stig/landscape.conf
+++ b/docs/assets/disa-stig/landscape.conf
@@ -29,6 +29,7 @@
     Alias /offline /opt/canonical/landscape/canonical/landscape/offline
     Alias /static /opt/canonical/landscape/canonical/static
     Alias /repository /var/lib/landscape/landscape-repository
+    Alias /publications /var/snap/landscape-debarchive/common/publications
 
 
     <Location "/repository">
@@ -41,6 +42,17 @@
      Allow from all
    </LocationMatch>
 
+   <Directory "/var/snap/landscape-debarchive/common/publications">
+     Options +Indexes
+     Order allow,deny
+     Allow from all
+     Require all granted
+   </Directory>
+
+   <Location "/publications">
+     Order allow,deny
+     Allow from all
+   </Location>
    <Location "/icons">
         Order allow,deny
         Allow from all
@@ -76,6 +88,7 @@
     RewriteCond %{REQUEST_URI} !^/static/
     RewriteCond %{REQUEST_URI} !^/offline/
     RewriteCond %{REQUEST_URI} !^/repository/
+    RewriteCond %{REQUEST_URI} !^/publications
     RewriteCond %{REQUEST_URI} !^/message-system
 
     # If you change the port number that Apache is providing SSL on, you must change the


### PR DESCRIPTION
STIG requires HTTPS connections for serving packages.

This change adds the debarchive filesystem package locations to the sample apache conf under 443/https for disa-stig deployments.