### PR TITLE
migrate old tutorial info to prevent packages from being installed

### DIFF
--- a/docs/how-to-guides/landscape-installation-and-set-up/juju-installation.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/juju-installation.md
@@ -15,13 +15,13 @@ For detailed instructions on deploying Landscape with Juju in a high-availabilit
 
 ## Install Juju
 
-[Install Juju](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-juju/) as a snap with this command:
+[Install Juju](https://canonical.com/juju/docs/juju-cli/latest/howto/manage-juju/) as a snap with this command:
 
 ```bash
 sudo snap install juju --classic
 ```
 
-To learn more about Juju and to bootstrap a Juju controller, check out their [getting started](https://canonical-juju.readthedocs-hosted.com/en/latest/user/tutorial/) page.
+To learn more about Juju and to bootstrap a Juju controller, check out their [getting started](https://canonical.com/juju/docs/juju-cli/latest/tutorial/) page.
 
 ## Deploy self-hosted Landscape Server
 

--- a/docs/how-to-guides/web-portal/web-portal-24-04-or-later/manage-packages-and-snaps.md
+++ b/docs/how-to-guides/web-portal/web-portal-24-04-or-later/manage-packages-and-snaps.md
@@ -7,7 +7,7 @@ myst:
 (how-to-web-portal-manage-snaps)=
 # How to manage packages and snaps
 
-You can manage packages (Debian) and snaps from the web portal for each managed instance in your Landscape account.
+You can manage packages (Debian) and snaps from the web portal for each managed instance in your Landscape account. You can also use package profiles and remote script execution to apply package management policies across multiple instances.
 
 ## Packages
 
@@ -30,6 +30,27 @@ You can perform different actions with packages from an instance's **Packages** 
    - You can only downgrade an individual package, not multiple packages at once.
 
 All actions will ask you to complete a form or confirm before Landscape sends an activity to perform the action. You can check the status of activities in the **Activities** page from the sidebar.
+
+### Prevent a package from being installed
+
+You can prevent a Debian package from being installed on groups of managed instances by combining remote script execution with a package profile.
+
+This workflow is for APT-managed Debian packages on instances using the Landscape Client deb package. If you're using the Landscape Client snap (with Ubuntu Core), remote script execution is still available, but APT-based package blocking isn't.
+
+1. Add and run a script on the target instances (see {ref}`how-to-web-portal-use-remote-script-execution`) that creates `/etc/apt/preferences.d/<PACKAGE>.pref` with `Pin-Priority` set below `0`.
+   For example, to block `audacity`, the preferences file content should be:
+
+   ```text
+   Package: audacity
+   Pin: release *
+   Pin-Priority: -1
+   ```
+
+1. Create a package profile with a manual `Conflicts with` constraint for that package, then associate it with the target access group or tags (see {ref}`how-to-web-portal-use-profiles`).
+
+APT preferences prevent future installation, but they don't remove a package that's already installed. The package profile is what enforces removal if the package appears on associated instances.
+
+To allow the package again later, remove the APT preferences file from target instances, then remove or update the related package profile constraint.
 
 ## Snaps
 

--- a/docs/how-to-guides/web-portal/web-portal-24-04-or-later/use-remote-script-execution.md
+++ b/docs/how-to-guides/web-portal/web-portal-24-04-or-later/use-remote-script-execution.md
@@ -31,7 +31,7 @@ You can edit, archive, run and more on the script using the dot menu under **Act
 
 To run a script on one or more instances:
 
-1. Go to **Instances** from the sidebar > Select the target instance(s) > **Run script**
+1. Go to **Instances** from the sidebar > Select the target instance(s) > **Operations** > **Run script**
 1. In the side panel that opens, complete the form > **Run**
    - Note: **Time limit** is the maximum time the script can run before Landscape forcibly terminates it
 

--- a/docs/how-to-guides/wsl-integration/register-wsl-hosts.md
+++ b/docs/how-to-guides/wsl-integration/register-wsl-hosts.md
@@ -111,7 +111,7 @@ Your Windows host machine is now registered in Landscape. To register WSL-Ubuntu
 (howto-heading-register-wsl-host-troubleshoot)=
 ## (If necessary) Troubleshoot
 
-> See also: [Ubuntu Pro for WSL's logs](https://documentation.ubuntu.com/wsl/en/latest/howto/06-access-the-logs/)
+> See also: [Ubuntu Pro for WSL's logs](https://documentation.ubuntu.com/wsl/latest/howto/06-access-the-logs/)
 
 If your Windows host machine doesn’t appear as a pending instance in your Landscape account:
 

--- a/docs/reuse/repository-disk-space.md
+++ b/docs/reuse/repository-disk-space.md
@@ -12,4 +12,4 @@ Packages will be downloaded to `/var/lib/landscape/landscape-repository/standalo
 
 These estimates are only a subset, and it doesn't include arm and other architectures. Including these will use more disk space.
 
-Note that the [restricted component](https://help.ubuntu.com/community/Repositories#Restricted) is usually large, and it contains proprietary packages and drivers that aren't fully open-source (e.g., Nvidia graphics drivers). If you know you won't need these packages and drivers, you could significantly reduce the size of your mirrors by not mirroring the restricted component.
+Note that the [restricted component](https://ubuntu.com/project/docs/how-ubuntu-is-made/concepts/package-archive/) is usually large, and it contains proprietary packages and drivers that aren't fully open-source (e.g., Nvidia graphics drivers). If you know you won't need these packages and drivers, you could significantly reduce the size of your mirrors by not mirroring the restricted component.


### PR DESCRIPTION
Migrate the relevant content from [an older Ubuntu Tutorial](https://discourse.ubuntu.com/t/blocking-software-package-installation-with-landscape/27449) into our public docs.