### PR TITLE
Add GH Action to sync branches

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -26,7 +26,8 @@ jobs:
     if: github.repository == 'canonical/landscape-documentation'
 
     env:
-      GH_TOKEN: ${{ secrets.LANDSCAPE_SYNC_TOKEN }}
+      GH_TOKEN: ${{ secrets.LANDSCAPE_SYNC_TOKEN != '' && secrets.LANDSCAPE_SYNC_TOKEN || github.token }}
+      DRY_RUN: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
 
     steps:
       - name: Check whether develop is already up to date
@@ -46,8 +47,6 @@ jobs:
         if: steps.compare.outputs.ahead_by != '0'
         id: ensure-pr
         run: |
-          dry_run="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}"
-
           pr_number=$(gh pr list \
             --repo "${{ github.repository }}" \
             --base develop \
@@ -59,7 +58,7 @@ jobs:
           if [ -n "${pr_number}" ]; then
             echo "Reusing existing open PR #${pr_number}."
           else
-            if [ "${dry_run}" = "true" ]; then
+            if [ "${DRY_RUN}" = "true" ]; then
               echo "Dry-run mode: no existing PR found, and PR creation is skipped."
             else
               echo "No existing open PR found – creating one."
@@ -77,7 +76,7 @@ jobs:
           echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
 
       - name: Enable auto-merge on the sync PR
-        if: steps.compare.outputs.ahead_by != '0' && !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') && steps.ensure-pr.outputs.pr_number != ''
+        if: steps.compare.outputs.ahead_by != '0' && env.DRY_RUN != 'true' && steps.ensure-pr.outputs.pr_number != ''
         run: |
           pr_number="${{ steps.ensure-pr.outputs.pr_number }}"
           already_set=$(gh pr view "${pr_number}" \

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -33,7 +33,7 @@ jobs:
             echo "main is ${ahead_by} commit(s) ahead of develop – sync required."
           fi
 
-      - name: Ensure a sync PR exists
+      - name: Create or reuse sync PR
         if: steps.compare.outputs.ahead_by != '0'
         id: ensure-pr
         run: |

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -1,0 +1,100 @@
+name: Sync main into develop
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run checks only; do not create PRs or enable auto-merge"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: sync-main-to-develop
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Merge main into develop
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/landscape-documentation'
+
+    env:
+      GH_TOKEN: ${{ secrets.LANDSCAPE_SYNC_TOKEN }}
+
+    steps:
+      - name: Check whether develop is already up to date
+        id: compare
+        run: |
+          ahead_by=$(gh api \
+            "repos/${{ github.repository }}/compare/develop...main" \
+            --jq '.ahead_by')
+          echo "ahead_by=${ahead_by}" >> "$GITHUB_OUTPUT"
+          if [ "${ahead_by}" = "0" ]; then
+            echo "develop is already up to date with main – no sync needed."
+          else
+            echo "main is ${ahead_by} commit(s) ahead of develop – sync required."
+          fi
+
+      - name: Ensure a sync PR exists
+        if: steps.compare.outputs.ahead_by != '0'
+        id: ensure-pr
+        run: |
+          dry_run="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}"
+
+          pr_number=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --base develop \
+            --head main \
+            --state open \
+            --json number \
+            --jq '.[0].number // ""')
+
+          if [ -n "${pr_number}" ]; then
+            echo "Reusing existing open PR #${pr_number}."
+          else
+            if [ "${dry_run}" = "true" ]; then
+              echo "Dry-run mode: no existing PR found, and PR creation is skipped."
+            else
+              echo "No existing open PR found – creating one."
+              pr_url=$(gh pr create \
+                --repo "${{ github.repository }}" \
+                --base develop \
+                --head main \
+                --title "merge: sync main into develop" \
+                --body "Automated sync of main into develop. Triggered by commit ${{ github.sha }}.")
+              pr_number=$(echo "${pr_url}" | grep -oE '[0-9]+$')
+              echo "Created PR #${pr_number}: ${pr_url}"
+            fi
+          fi
+
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge on the sync PR
+        if: steps.compare.outputs.ahead_by != '0' && !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') && steps.ensure-pr.outputs.pr_number != ''
+        run: |
+          pr_number="${{ steps.ensure-pr.outputs.pr_number }}"
+          already_set=$(gh pr view "${pr_number}" \
+            --repo "${{ github.repository }}" \
+            --json autoMergeRequest \
+            --jq '.autoMergeRequest != null')
+
+          if [ "${already_set}" = "true" ]; then
+            echo "Auto-merge is already enabled on PR #${pr_number} – nothing to change."
+          else
+            output=$(gh pr merge --auto --merge "${pr_number}" \
+              --repo "${{ github.repository }}" 2>&1) && rc=0 || rc=$?
+            if [ "${rc}" -eq 0 ]; then
+              echo "Auto-merge (merge commit) enabled on PR #${pr_number}."
+            else
+              echo "::warning::Could not enable auto-merge on PR #${pr_number}."
+              echo "::warning::${output}"
+              echo "Possible causes: 'Allow auto-merge' is disabled in repository settings,"
+              echo "the PAT lacks sufficient permissions, or branch protection prevents it."
+              echo "The PR remains open. Resolve the blocker and re-run this workflow,"
+              echo "or merge PR #${pr_number} manually."
+            fi
+          fi

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -4,16 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: "Run checks only; do not create PRs or enable auto-merge"
-        required: false
-        default: false
-        type: boolean
 
 concurrency:
   group: sync-main-to-develop
@@ -26,8 +17,7 @@ jobs:
     if: github.repository == 'canonical/landscape-documentation'
 
     env:
-      GH_TOKEN: ${{ secrets.LANDSCAPE_SYNC_TOKEN != '' && secrets.LANDSCAPE_SYNC_TOKEN || github.token }}
-      DRY_RUN: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
+      GH_TOKEN: ${{ secrets.LANDSCAPE_SYNC_TOKEN }}
 
     steps:
       - name: Check whether develop is already up to date
@@ -58,25 +48,20 @@ jobs:
           if [ -n "${pr_number}" ]; then
             echo "Reusing existing open PR #${pr_number}."
           else
-            if [ "${DRY_RUN}" = "true" ]; then
-              echo "Dry-run mode: no existing PR found, and PR creation is skipped."
-            else
-              echo "No existing open PR found – creating one."
-              pr_url=$(gh pr create \
-                --repo "${{ github.repository }}" \
-                --base develop \
-                --head main \
-                --title "merge: sync main into develop" \
-                --body "Automated sync of main into develop. Triggered by commit ${{ github.sha }}.")
-              pr_number=$(echo "${pr_url}" | grep -oE '[0-9]+$')
-              echo "Created PR #${pr_number}: ${pr_url}"
-            fi
+            pr_url=$(gh pr create \
+              --repo "${{ github.repository }}" \
+              --base develop \
+              --head main \
+              --title "merge: sync main into develop" \
+              --body "Automated sync of main into develop. Triggered by commit ${{ github.sha }}.")
+            pr_number=$(echo "${pr_url}" | grep -oE '[0-9]+$')
+            echo "Created PR #${pr_number}: ${pr_url}"
           fi
 
           echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
 
       - name: Enable auto-merge on the sync PR
-        if: steps.compare.outputs.ahead_by != '0' && env.DRY_RUN != 'true' && steps.ensure-pr.outputs.pr_number != ''
+        if: steps.compare.outputs.ahead_by != '0' && steps.ensure-pr.outputs.pr_number != ''
         run: |
           pr_number="${{ steps.ensure-pr.outputs.pr_number }}"
           already_set=$(gh pr view "${pr_number}" \
@@ -85,18 +70,14 @@ jobs:
             --jq '.autoMergeRequest != null')
 
           if [ "${already_set}" = "true" ]; then
-            echo "Auto-merge is already enabled on PR #${pr_number} – nothing to change."
+            echo "Auto-merge already enabled on PR #${pr_number}."
           else
             output=$(gh pr merge --auto --merge "${pr_number}" \
+              --subject "auto: sync main into develop" \
               --repo "${{ github.repository }}" 2>&1) && rc=0 || rc=$?
             if [ "${rc}" -eq 0 ]; then
               echo "Auto-merge (merge commit) enabled on PR #${pr_number}."
             else
-              echo "::warning::Could not enable auto-merge on PR #${pr_number}."
-              echo "::warning::${output}"
-              echo "Possible causes: 'Allow auto-merge' is disabled in repository settings,"
-              echo "the PAT lacks sufficient permissions, or branch protection prevents it."
-              echo "The PR remains open. Resolve the blocker and re-run this workflow,"
-              echo "or merge PR #${pr_number} manually."
+              echo "::warning::Could not enable auto-merge on PR #${pr_number}: ${output}"
             fi
           fi


### PR DESCRIPTION
GH Action to keep the `develop` branch up to date . It's setup this way because we have a branch protection that requires a PR

I tested that it works (not the PR part):
- [Before merging `main` into `develop`](https://github.com/canonical/landscape-documentation/actions/runs/31744684052/job/94596235781#step:2:16)
- [After merging `main` into `develop`](https://github.com/canonical/landscape-documentation/actions/runs/31744684052/job/94605668270#step:2:16)

**For reviewer:**
Tell me with your GH wisdom how this looks. I don't think it can be tested further than the links I've included. Ideally it will open a PR on each new merge to `main`, auto-merge if it can, otherwise leave the PR there for manual review