### PR TITLE
Add NVIDIA DGX Spark docs

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -473,3 +473,8 @@ MikeT
 gh
 Owsalla
 TropicolX
+
+# API reference
+Debarchive
+debarchive
+HTTPie

--- a/docs/explanation/related-tools/index.md
+++ b/docs/explanation/related-tools/index.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Discover how Landscape integrates with related tools like Ansible for complementary systems management and automation workflows."
+    description: "Discover how Landscape relates to tools and platforms such as Ansible and NVIDIA DGX Spark for complementary systems management and automation workflows."
 ---
 
 (explanation-related-tools-index)=
@@ -15,3 +15,4 @@ Landscape can work alongside other systems management and automation tools. Lear
 :glob:
 
 Landscape and Ansible <ansible>
+Landscape and NVIDIA DGX Spark <nvidia-dgx-spark>

--- a/docs/explanation/related-tools/nvidia-dgx-spark.md
+++ b/docs/explanation/related-tools/nvidia-dgx-spark.md
@@ -29,6 +29,8 @@ Some DGX Spark operations are specific to the platform rather than to Ubuntu. Fo
 - **[Production tools](https://docs.nvidia.com/dgx/dgx-spark/enterprise-fleet-lifecycle.html#production-tools-11)**, which NVIDIA intends for general fleet automation.
 - **[Landscape reference scripts](https://docs.nvidia.com/dgx/dgx-spark/enterprise-fleet-lifecycle.html#canonical-landscape-reference-scripts-8)**, which are example implementations written for Landscape's remote script execution. They return short output and write detailed evidence to the DGX Spark itself.
 
+You can run both production tools and Landscape reference scripts on one or more DGX Spark systems, using either the Landscape web portal or the API.
+
 NVIDIA provides the reference scripts as examples for customer adaptation rather than supported production software, so treat them as a starting point and review them before relying on them. A DGX Spark must be registered with Landscape before you can use the scripts.
 
 Running these scripts through Landscape means DGX-specific tasks use the same targeting and activity history as your other scripted operations. For what each script does and how to interpret its results, see [NVIDIA's Enterprise Lifecycle Integration documentation](https://docs.nvidia.com/dgx/dgx-spark/enterprise-fleet-lifecycle.html).

--- a/docs/explanation/related-tools/nvidia-dgx-spark.md
+++ b/docs/explanation/related-tools/nvidia-dgx-spark.md
@@ -1,45 +1,43 @@
 ---
 myst:
   html_meta:
-    description: "Understand how Landscape and NVIDIA DGX Spark work together for operating-system management and NVIDIA reference-script execution."
+    description: "Understand how Landscape manages NVIDIA DGX Spark systems running DGX OS, and how NVIDIA's Landscape reference scripts fit into that workflow."
 ---
 
 (explanation-related-tools-nvidia-dgx-spark)=
 # Landscape and NVIDIA DGX Spark
 
-NVIDIA DGX Spark runs DGX OS, a customized Linux distribution based on Ubuntu. Landscape can manage the operating-system environment on a DGX Spark after the system is enrolled as a Landscape client. NVIDIA also provides Landscape-specific reference scripts for selected DGX Spark operations.
+[NVIDIA DGX Spark](https://docs.nvidia.com/dgx/dgx-spark/) is a compact AI computer that runs DGX OS, NVIDIA's customized Linux distribution based on Ubuntu. Organizations can manage multiple DGX Spark systems centrally with Landscape, alongside their other Ubuntu systems.
 
-For the setup procedure, see {ref}`Set up NVIDIA DGX Spark for Landscape management <how-to-set-up-nvidia-dgx-spark>`. For using NVIDIA's scripts after enrollment, see {ref}`Use NVIDIA DGX Spark management scripts with Landscape <how-to-manage-nvidia-dgx-spark>`.
+NVIDIA describes Landscape as its [primary recommended management platform for DGX Spark](https://docs.nvidia.com/dgx/dgx-spark/enterprise-fleet-lifecycle.html). Landscape is available with [Ubuntu Pro](https://ubuntu.com/pro) subscriptions. This page describes how Landscape and DGX Spark fit together.
 
-Landscape and NVIDIA documentation have different areas of responsibility. Landscape documents the client, web portal, activities, and management workflows. NVIDIA remains the source of truth for DGX Spark, DGX OS, and the behavior of its tools and reference scripts.
+## How Landscape manages a DGX Spark
 
-## Landscape's role
+Landscape manages a DGX Spark like any other Ubuntu-based system. Landscape Client is the software that runs on the DGX Spark and communicates with your Landscape server. After you register your DGX Spark with Landscape, the DGX Spark appears in your Landscape account as a managed instance alongside your other machines.
 
-Landscape provides the management functions that apply to an enrolled client, including:
+From there, you use the same Landscape features you use everywhere else, such as:
 
-- system status and inventory information reported by Landscape Client;
-- package and security-update management;
-- tags and access groups for organizing and targeting instances; and
-- remote script execution and the activities that track those operations.
+- Inventory and status reported by Landscape Client,
+- Package and security-update management,
+- {ref}`Tags <reference-terms-tags>` and {ref}`access groups <reference-terms-access-groups>`, which let you group DGX Spark systems and target actions at them, and
+- {ref}`Remote script execution <explanation-remote-script-execution>`, where each run is tracked as an {ref}`activity <explanation-activities>`.
 
-These are existing Landscape capabilities, not DGX Spark-specific features. See the documentation for {ref}`remote script execution <explanation-remote-script-execution>`, {ref}`activities <explanation-activities>`, and the {ref}`Landscape web portal <how-to-guides-web-portal-index>`.
+## NVIDIA's Landscape reference scripts
 
-## NVIDIA's role
+Some DGX Spark operations are specific to the platform rather than to Ubuntu. For these, [NVIDIA publishes](https://docs.nvidia.com/dgx/dgx-spark/enterprise-fleet-lifecycle.html) two kinds of automation:
 
-NVIDIA remains authoritative for DGX Spark and DGX OS, including platform compatibility, drivers, firmware, recovery, provisioning, hardware-level management, diagnostics, and the detailed behavior of NVIDIA tools.
+- **[Production tools](https://docs.nvidia.com/dgx/dgx-spark/enterprise-fleet-lifecycle.html#production-tools-11)**, which NVIDIA intends for general fleet automation.
+- **[Landscape reference scripts](https://docs.nvidia.com/dgx/dgx-spark/enterprise-fleet-lifecycle.html#canonical-landscape-reference-scripts-8)**, which are example implementations written for Landscape's remote script execution. They return short output and write detailed evidence to the DGX Spark itself.
 
-NVIDIA's [Enterprise Lifecycle Integration](https://docs.nvidia.com/dgx/dgx-spark/enterprise-fleet-lifecycle.html) documentation distinguishes between production tools and Landscape reference scripts. The production tools are intended for fleet automation. The Landscape scripts are reference implementations designed for use with Landscape remote script execution and may require adaptation for an organization's processes. They are not a replacement for NVIDIA's production tools.
+NVIDIA provides the reference scripts as examples for customer adaptation rather than supported production software, so treat them as a starting point and review them before relying on them. A DGX Spark must be registered with Landscape before you can use the scripts.
 
-## How the reference scripts fit
+Running these scripts through Landscape means DGX-specific tasks use the same targeting and activity history as your other scripted operations. For what each script does and how to interpret its results, see [NVIDIA's Enterprise Lifecycle Integration documentation](https://docs.nvidia.com/dgx/dgx-spark/enterprise-fleet-lifecycle.html).
 
-The [NVIDIA Enterprise Lifecycle Integration Scripts package](https://docscontent.nvidia.com/dc/04/5167e1c14532bac843d48d29bf36/enterprise-lifecycle-integration-scripts-20260520-1602.zip) contains the Landscape reference scripts and their setup documentation. Use NVIDIA's documentation to determine which script is appropriate, what the script requires, what it changes, and how to interpret its output.
+## Other DGX Spark operations
 
-Use Landscape to make a reference script available to enrolled clients, select the target systems, run the script, and inspect the resulting activity. Landscape does not interpret NVIDIA's output format or take ownership of the evidence that a script writes on the DGX Spark.
+Landscape manages the Ubuntu-based DGX OS. Use NVIDIA's tooling and [DGX Spark documentation](https://docs.nvidia.com/dgx/dgx-spark/) for hardware, firmware, drivers, recovery, provisioning, and out-of-band management.
 
-Landscape limits the output returned by remote script execution according to the client's `script_output_limit` setting. NVIDIA's reference scripts are designed to keep standard output short and may store detailed evidence on the client. Do not assume that all script output or NVIDIA evidence is retained in Landscape; follow NVIDIA's instructions for detailed evidence and troubleshooting.
+## Next steps
 
-For the Landscape workflow, see {ref}`how-to-manage-nvidia-dgx-spark`.
-
-## Hardware-level management
-
-Landscape manages DGX Spark through Landscape Client at the operating-system level. Hardware-level and out-of-band operations remain part of NVIDIA's DGX Spark management model. Consult [NVIDIA's DGX Spark documentation](https://docs.nvidia.com/dgx/dgx-spark/) for those operations.
+- {ref}`Set up NVIDIA DGX Spark for Landscape management <how-to-set-up-nvidia-dgx-spark>`
+- {ref}`Use NVIDIA DGX Spark management scripts with Landscape <how-to-manage-nvidia-dgx-spark>`

--- a/docs/explanation/related-tools/nvidia-dgx-spark.md
+++ b/docs/explanation/related-tools/nvidia-dgx-spark.md
@@ -1,0 +1,45 @@
+---
+myst:
+  html_meta:
+    description: "Understand how Landscape and NVIDIA DGX Spark work together for operating-system management and NVIDIA reference-script execution."
+---
+
+(explanation-related-tools-nvidia-dgx-spark)=
+# Landscape and NVIDIA DGX Spark
+
+NVIDIA DGX Spark runs DGX OS, a customized Linux distribution based on Ubuntu. Landscape can manage the operating-system environment on a DGX Spark after the system is enrolled as a Landscape client. NVIDIA also provides Landscape-specific reference scripts for selected DGX Spark operations.
+
+For the setup procedure, see {ref}`Set up NVIDIA DGX Spark for Landscape management <how-to-set-up-nvidia-dgx-spark>`. For using NVIDIA's scripts after enrollment, see {ref}`Use NVIDIA DGX Spark management scripts with Landscape <how-to-manage-nvidia-dgx-spark>`.
+
+Landscape and NVIDIA documentation have different areas of responsibility. Landscape documents the client, web portal, activities, and management workflows. NVIDIA remains the source of truth for DGX Spark, DGX OS, and the behavior of its tools and reference scripts.
+
+## Landscape's role
+
+Landscape provides the management functions that apply to an enrolled client, including:
+
+- system status and inventory information reported by Landscape Client;
+- package and security-update management;
+- tags and access groups for organizing and targeting instances; and
+- remote script execution and the activities that track those operations.
+
+These are existing Landscape capabilities, not DGX Spark-specific features. See the documentation for {ref}`remote script execution <explanation-remote-script-execution>`, {ref}`activities <explanation-activities>`, and the {ref}`Landscape web portal <how-to-guides-web-portal-index>`.
+
+## NVIDIA's role
+
+NVIDIA remains authoritative for DGX Spark and DGX OS, including platform compatibility, drivers, firmware, recovery, provisioning, hardware-level management, diagnostics, and the detailed behavior of NVIDIA tools.
+
+NVIDIA's [Enterprise Lifecycle Integration](https://docs.nvidia.com/dgx/dgx-spark/enterprise-fleet-lifecycle.html) documentation distinguishes between production tools and Landscape reference scripts. The production tools are intended for fleet automation. The Landscape scripts are reference implementations designed for use with Landscape remote script execution and may require adaptation for an organization's processes. They are not a replacement for NVIDIA's production tools.
+
+## How the reference scripts fit
+
+The [NVIDIA Enterprise Lifecycle Integration Scripts package](https://docscontent.nvidia.com/dc/04/5167e1c14532bac843d48d29bf36/enterprise-lifecycle-integration-scripts-20260520-1602.zip) contains the Landscape reference scripts and their setup documentation. Use NVIDIA's documentation to determine which script is appropriate, what the script requires, what it changes, and how to interpret its output.
+
+Use Landscape to make a reference script available to enrolled clients, select the target systems, run the script, and inspect the resulting activity. Landscape does not interpret NVIDIA's output format or take ownership of the evidence that a script writes on the DGX Spark.
+
+Landscape limits the output returned by remote script execution according to the client's `script_output_limit` setting. NVIDIA's reference scripts are designed to keep standard output short and may store detailed evidence on the client. Do not assume that all script output or NVIDIA evidence is retained in Landscape; follow NVIDIA's instructions for detailed evidence and troubleshooting.
+
+For the Landscape workflow, see {ref}`how-to-manage-nvidia-dgx-spark`.
+
+## Hardware-level management
+
+Landscape manages DGX Spark through Landscape Client at the operating-system level. Hardware-level and out-of-band operations remain part of NVIDIA's DGX Spark management model. Consult [NVIDIA's DGX Spark documentation](https://docs.nvidia.com/dgx/dgx-spark/) for those operations.

--- a/docs/explanation/related-tools/nvidia-dgx-spark.md
+++ b/docs/explanation/related-tools/nvidia-dgx-spark.md
@@ -35,7 +35,7 @@ Running these scripts through Landscape means DGX-specific tasks use the same ta
 
 ## Other DGX Spark operations
 
-Landscape manages the Ubuntu-based DGX OS. Use NVIDIA's tooling and [DGX Spark documentation](https://docs.nvidia.com/dgx/dgx-spark/) for hardware, firmware, drivers, recovery, provisioning, and out-of-band management.
+Landscape manages the Ubuntu-based DGX OS installation. Use NVIDIA's tooling and [DGX Spark documentation](https://docs.nvidia.com/dgx/dgx-spark/) for hardware, firmware, drivers, recovery, provisioning, and out-of-band management.
 
 ## Next steps
 

--- a/docs/how-to-guides/index.md
+++ b/docs/how-to-guides/index.md
@@ -156,7 +156,7 @@ api/index
 (how-to-index-heading-nvidia-dgx-spark)=
 ## NVIDIA DGX Spark
 
-Use NVIDIA's Landscape reference scripts with Landscape remote script execution on enrolled DGX Spark systems.
+Use NVIDIA's Landscape reference scripts with Landscape remote script execution on registered DGX Spark systems.
 
 ```{toctree}
 :titlesonly:

--- a/docs/how-to-guides/index.md
+++ b/docs/how-to-guides/index.md
@@ -153,6 +153,18 @@ Access Landscape programmatically using the REST API or legacy API for automatio
 api/index
 ```
 
+(how-to-index-heading-nvidia-dgx-spark)=
+## NVIDIA DGX Spark
+
+Use NVIDIA's Landscape reference scripts with Landscape remote script execution on enrolled DGX Spark systems.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+nvidia-dgx-spark/index
+```
+
 (how-to-index-heading-troubleshooting)=
 ## Troubleshooting
 

--- a/docs/how-to-guides/index.md
+++ b/docs/how-to-guides/index.md
@@ -156,7 +156,7 @@ api/index
 (how-to-index-heading-nvidia-dgx-spark)=
 ## NVIDIA DGX Spark
 
-Use NVIDIA's Landscape reference scripts with Landscape remote script execution on registered DGX Spark systems.
+Register NVIDIA DGX Spark systems with Landscape and use NVIDIA's Landscape reference scripts with Landscape remote script execution.
 
 ```{toctree}
 :titlesonly:

--- a/docs/how-to-guides/landscape-installation-and-set-up/cloud-providers/install-on-google-cloud.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/cloud-providers/install-on-google-cloud.md
@@ -239,7 +239,7 @@ To delete the cloud-init `user-data` key, run:
 gcloud compute instances remove-metadata landscape --zone $ZONE --keys=user-data
 ```
 
-Cloud-init scripts are provided in a custom metadata key named `user-data`. The `user-data` key is consumed during instance creation and is executed when the instance starts. Sensitive information such as API keys shouldn’t be left visible within the custom metadata of the VM or in the cloud dashboard. Once the cloud-init process is complete, it’s safe to delete the cloud-init `user-data` key.
+cloud-init scripts are provided in a custom metadata key named `user-data`. The `user-data` key is consumed during instance creation and is executed when the instance starts. Sensitive information such as API keys shouldn’t be left visible within the custom metadata of the VM or in the cloud dashboard. Once the cloud-init process is complete, it’s safe to delete the cloud-init `user-data` key.
 
 ## (Optional) Perform a complete teardown
 

--- a/docs/how-to-guides/landscape-installation-and-set-up/install-in-a-lxd-container.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/install-in-a-lxd-container.md
@@ -7,7 +7,7 @@ myst:
 (how-to-install-in-lxd-container)=
 # How to install Landscape Server in a LXD container using cloud-init
 
-This guide shows you how to deploy Landscape Server in a single LXD container using cloud-init. This approach is intended for testing and development environments, as it automates the entire setup process with a single cloud-init configuration file. Cloud-init handles the installation of all Landscape components, configuration of networking, certificates, and system settings.
+This guide shows you how to deploy Landscape Server in a single LXD container using cloud-init. This approach is intended for testing and development environments, as it automates the entire setup process with a single cloud-init configuration file. cloud-init handles the installation of all Landscape components, configuration of networking, certificates, and system settings.
 
 ## Prepare your cloud-init configuration
 
@@ -105,7 +105,7 @@ lxc network set lxdbr0 bridge.mtu=$(ip link show $INTERFACE | awk '/mtu/ {print 
 
 ## Deploy Landscape with cloud-init
 
-Cloud-init will automatically deploy Landscape and configure port forwarding for ports 80, 443, and 6554 to make the instance accessible.
+cloud-init will automatically deploy Landscape and configure port forwarding for ports 80, 443, and 6554 to make the instance accessible.
 
 **Step 1:** Install Landscape Quickstart inside a LXD container using `cloud-init.yaml`. This command installs Landscape on Ubuntu 24.04 LTS.
 

--- a/docs/how-to-guides/landscape-installation-and-set-up/install-landscape-client.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/install-landscape-client.md
@@ -127,7 +127,7 @@ This method is suitable when using charmed operators. To install Landscape Clien
 
 For more information on the Landscape client charm, see the [Charmhub documentation](https://charmhub.io/landscape-client).
 
-## Install Landscape Client with Cloud-init
+## Install Landscape Client with cloud-init
 
 This method is suitable if it's available during a machine's provisioning stage. To install Landscape Client with cloud-init:
 

--- a/docs/how-to-guides/nvidia-dgx-spark/index.md
+++ b/docs/how-to-guides/nvidia-dgx-spark/index.md
@@ -11,7 +11,7 @@ Use these guides to bring an existing NVIDIA DGX Spark under Landscape managemen
 
 ## Set up and register
 
-Enroll the DGX Spark in Landscape and enable the client capability required by the scripts.
+Register the DGX Spark with Landscape and enable the client capability required by the scripts.
 
 ```{toctree}
 :titlesonly:

--- a/docs/how-to-guides/nvidia-dgx-spark/index.md
+++ b/docs/how-to-guides/nvidia-dgx-spark/index.md
@@ -1,0 +1,34 @@
+---
+myst:
+  html_meta:
+    description: "Set up NVIDIA DGX Spark systems in Landscape and use NVIDIA's Landscape reference scripts."
+---
+
+(how-to-guides-nvidia-dgx-spark-index)=
+# NVIDIA DGX Spark
+
+Use these guides to bring an existing NVIDIA DGX Spark under Landscape management and run NVIDIA's Landscape reference scripts.
+
+## Set up and register
+
+Enroll the DGX Spark in Landscape and enable the client capability required by the scripts.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+Set up NVIDIA DGX Spark for Landscape management <set-up-nvidia-dgx-spark>
+```
+
+## Use NVIDIA reference scripts
+
+Make NVIDIA's Landscape reference scripts available to Landscape, run them on selected DGX Spark systems, and inspect their activities and results.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+Use NVIDIA DGX Spark management scripts with Landscape <manage-nvidia-dgx-spark>
+```
+
+For the conceptual relationship between Landscape and DGX Spark, see {ref}`Landscape and NVIDIA DGX Spark <explanation-related-tools-nvidia-dgx-spark>`.

--- a/docs/how-to-guides/nvidia-dgx-spark/manage-nvidia-dgx-spark.md
+++ b/docs/how-to-guides/nvidia-dgx-spark/manage-nvidia-dgx-spark.md
@@ -7,9 +7,9 @@ myst:
 (how-to-manage-nvidia-dgx-spark)=
 # Use NVIDIA DGX Spark management scripts with Landscape
 
-Use Landscape remote script execution to run NVIDIA's Landscape reference scripts on registered DGX Spark systems. This guide covers the integration boundary; use NVIDIA's documentation for the script's purpose, prerequisites, behavior, and output.
+This guide describes how to run NVIDIA's Landscape reference scripts on registered DGX Spark systems using Landscape remote script execution. For each script's purpose, prerequisites, behavior, and output, see NVIDIA's documentation.
 
-Before starting, complete {ref}`Set up NVIDIA DGX Spark for Landscape management <how-to-set-up-nvidia-dgx-spark>`.
+Before you start, complete {ref}`Set up NVIDIA DGX Spark for Landscape management <how-to-set-up-nvidia-dgx-spark>`.
 
 ## Before you begin
 
@@ -27,7 +27,7 @@ For access groups and permissions, see the {ref}`Landscape web portal documentat
 1. Extract the package and read its `README.md` and `LANDSCAPE_REFERENCE_SCRIPTS_SETUP.md` documentation before selecting a script.
 1. Follow NVIDIA's instructions for the selected script's dependencies, permissions, and any files that must already be present on the DGX Spark.
 
-The package contains both production tools and Landscape reference scripts. This guide concerns the Landscape reference scripts only. Do not assume that a production tool can be run through Landscape without following NVIDIA's deployment instructions.
+The package contains both production tools and Landscape reference scripts. This guide covers the Landscape reference scripts. To run a production tool through Landscape, follow NVIDIA's deployment instructions for that tool.
 
 ## Enable remote script execution
 

--- a/docs/how-to-guides/nvidia-dgx-spark/manage-nvidia-dgx-spark.md
+++ b/docs/how-to-guides/nvidia-dgx-spark/manage-nvidia-dgx-spark.md
@@ -24,7 +24,7 @@ The package contains both production tools and Landscape reference scripts. This
 For each script you plan to use:
 
 1. In the Landscape web portal, go to **Scripts** from the sidebar > **Add script**.
-1. Copy the NVIDIA reference script into the script editor and complete the form, including its title and access group.
+1. Copy the NVIDIA reference script into the script editor and complete the form, including its title and access group. Keep the script's first line, such as `#!/bin/bash`, because Landscape determines the interpreter from it.
 1. Add attachments only when the NVIDIA script documentation requires them, such as a configuration file that the script reads. Use the attachment names expected by that script.
 1. **Add script**
 

--- a/docs/how-to-guides/nvidia-dgx-spark/manage-nvidia-dgx-spark.md
+++ b/docs/how-to-guides/nvidia-dgx-spark/manage-nvidia-dgx-spark.md
@@ -1,0 +1,63 @@
+---
+myst:
+  html_meta:
+    description: "Use NVIDIA DGX Spark Landscape reference scripts with Landscape remote script execution."
+---
+
+(how-to-manage-nvidia-dgx-spark)=
+# Use NVIDIA DGX Spark management scripts with Landscape
+
+Use Landscape remote script execution to run NVIDIA's Landscape reference scripts on enrolled DGX Spark systems. This guide covers the integration boundary; use NVIDIA's documentation for the script's purpose, prerequisites, behavior, and output.
+
+Before starting, complete {ref}`Set up NVIDIA DGX Spark for Landscape management <how-to-set-up-nvidia-dgx-spark>`.
+
+## Before you begin
+
+You need:
+
+- a DGX Spark running the DGX OS baseline supported by the NVIDIA documentation for the script you intend to use;
+- the Landscape Client installed and registered on the DGX Spark; and
+- permission to add and run scripts in the relevant Landscape access group.
+
+For access groups and permissions, see the {ref}`Landscape web portal documentation <how-to-guides-web-portal-index>`.
+
+## Obtain the NVIDIA reference script
+
+1. Download the [NVIDIA Enterprise Lifecycle Integration Scripts package](https://docscontent.nvidia.com/dc/04/5167e1c14532bac843d48d29bf36/enterprise-lifecycle-integration-scripts-20260520-1602.zip).
+1. Extract the package and read its `README.md` and `LANDSCAPE_REFERENCE_SCRIPTS_SETUP.md` documentation before selecting a script.
+1. Follow NVIDIA's instructions for the selected script's dependencies, permissions, and any files that must already be present on the DGX Spark.
+
+The package contains both production tools and Landscape reference scripts. This guide concerns the Landscape reference scripts only. Do not assume that a production tool can be run through Landscape without following NVIDIA's deployment instructions.
+
+## Enable remote script execution
+
+Remote script execution must be enabled on each target Landscape Client. Follow {ref}`Enable script execution <howto-heading-client-enable-script-execution>` in the Landscape Client configuration guide. The guide documents the client configuration and the system users that can run scripts.
+
+## Add the script to Landscape
+
+1. In the Landscape web portal, go to **Scripts** > **Add script**.
+1. Copy the NVIDIA reference script into the script editor and complete the form, including its title and access group.
+1. Add attachments only when the NVIDIA script documentation requires them, and use the attachment names and paths expected by that script.
+1. Select **Add script**.
+
+These steps use Landscape's normal script workflow. For more information about adding scripts, see {ref}`How to use remote script execution <how-to-web-portal-use-remote-script-execution>`.
+
+## Run the script
+
+1. Identify the DGX Spark systems in Landscape. You can select instances directly or use the tags and access groups already used by your organization.
+1. Select the target instances and choose **Operations** > **Run script**.
+1. Select the NVIDIA reference script, choose the run-as user and time limit required by the NVIDIA script documentation, and select **Run**.
+
+Start with one DGX Spark or a small test group before running a state-changing script across a larger group. Apply NVIDIA's change-control guidance for scripts that modify the system or initiate updates.
+
+## Review the result
+
+Landscape creates an activity for each script execution. Monitor the activity from the **Activities** page or from the target instance's **Activities** tab. Select the activity to inspect its status and the output returned by the client.
+
+Landscape bounds returned script output using the client's `script_output_limit` configuration. A successful Landscape activity therefore does not mean that all NVIDIA evidence was transferred to Landscape. Use the output and local evidence according to the NVIDIA reference script's documentation, and contact NVIDIA for DGX-specific troubleshooting.
+
+For an optional recurring or post-enrollment workflow, supported self-hosted Landscape deployments can use {ref}`script profiles <how-to-web-portal-use-script-profiles>`. Script profiles are available only in self-hosted Landscape 25.04 and later; they are not the foundation of this guide.
+
+## Networking
+
+Use Landscape's {ref}`internal network requirements <reference-internal-network-requirements>` for Landscape Server and client connectivity. Remote script execution sends the script to Landscape Client for local execution; Landscape Server does not need to SSH into the DGX Spark for this workflow. This does not define or replace any separate NVIDIA hardware-management or site-specific network requirements.

--- a/docs/how-to-guides/nvidia-dgx-spark/manage-nvidia-dgx-spark.md
+++ b/docs/how-to-guides/nvidia-dgx-spark/manage-nvidia-dgx-spark.md
@@ -7,7 +7,7 @@ myst:
 (how-to-manage-nvidia-dgx-spark)=
 # Use NVIDIA DGX Spark management scripts with Landscape
 
-Use Landscape remote script execution to run NVIDIA's Landscape reference scripts on enrolled DGX Spark systems. This guide covers the integration boundary; use NVIDIA's documentation for the script's purpose, prerequisites, behavior, and output.
+Use Landscape remote script execution to run NVIDIA's Landscape reference scripts on registered DGX Spark systems. This guide covers the integration boundary; use NVIDIA's documentation for the script's purpose, prerequisites, behavior, and output.
 
 Before starting, complete {ref}`Set up NVIDIA DGX Spark for Landscape management <how-to-set-up-nvidia-dgx-spark>`.
 
@@ -23,7 +23,7 @@ For access groups and permissions, see the {ref}`Landscape web portal documentat
 
 ## Obtain the NVIDIA reference script
 
-1. Download the [NVIDIA Enterprise Lifecycle Integration Scripts package](https://docscontent.nvidia.com/dc/04/5167e1c14532bac843d48d29bf36/enterprise-lifecycle-integration-scripts-20260520-1602.zip).
+1. Open NVIDIA's [Enterprise Lifecycle Integration](https://docs.nvidia.com/dgx/dgx-spark/enterprise-fleet-lifecycle.html) documentation and follow its link to the Enterprise Lifecycle Integration Scripts package.
 1. Extract the package and read its `README.md` and `LANDSCAPE_REFERENCE_SCRIPTS_SETUP.md` documentation before selecting a script.
 1. Follow NVIDIA's instructions for the selected script's dependencies, permissions, and any files that must already be present on the DGX Spark.
 

--- a/docs/how-to-guides/nvidia-dgx-spark/manage-nvidia-dgx-spark.md
+++ b/docs/how-to-guides/nvidia-dgx-spark/manage-nvidia-dgx-spark.md
@@ -5,21 +5,11 @@ myst:
 ---
 
 (how-to-manage-nvidia-dgx-spark)=
-# Use NVIDIA DGX Spark management scripts with Landscape
+# How to use NVIDIA DGX Spark management scripts with Landscape
 
-This guide describes how to run NVIDIA's Landscape reference scripts on registered DGX Spark systems using Landscape remote script execution. For each script's purpose, prerequisites, behavior, and output, see NVIDIA's documentation.
+This guide describes how to run NVIDIA's Landscape reference scripts on registered DGX Spark systems using Landscape remote script execution. For each script's purpose, prerequisites, behavior, and output, see [NVIDIA's documentation](https://docs.nvidia.com/dgx/dgx-spark/enterprise-fleet-lifecycle.html).
 
-Before you start, complete {ref}`Set up NVIDIA DGX Spark for Landscape management <how-to-set-up-nvidia-dgx-spark>`.
-
-## Before you begin
-
-You need:
-
-- a DGX Spark running the DGX OS baseline supported by the NVIDIA documentation for the script you intend to use;
-- the Landscape Client installed and registered on the DGX Spark; and
-- permission to add and run scripts in the relevant Landscape access group.
-
-For access groups and permissions, see the {ref}`Landscape web portal documentation <how-to-guides-web-portal-index>`.
+Before you start, complete {ref}`Set up NVIDIA DGX Spark for Landscape management <how-to-set-up-nvidia-dgx-spark>`. Note that your user account needs permission to run scripts to perform the steps in this guide. If you set up the Landscape account, your user account has the necessary administrator privileges by default. Otherwise, see {ref}`How to manage administrators and roles <how-to-web-portal-manage-admins-and-roles>`.
 
 ## Obtain the NVIDIA reference script
 
@@ -27,37 +17,40 @@ For access groups and permissions, see the {ref}`Landscape web portal documentat
 1. Extract the package and read its `README.md` and `LANDSCAPE_REFERENCE_SCRIPTS_SETUP.md` documentation before selecting a script.
 1. Follow NVIDIA's instructions for the selected script's dependencies, permissions, and any files that must already be present on the DGX Spark.
 
-The package contains both production tools and Landscape reference scripts. This guide covers the Landscape reference scripts. To run a production tool through Landscape, follow NVIDIA's deployment instructions for that tool.
-
-## Enable remote script execution
-
-Remote script execution must be enabled on each target Landscape Client. Follow {ref}`Enable script execution <howto-heading-client-enable-script-execution>` in the Landscape Client configuration guide. The guide documents the client configuration and the system users that can run scripts.
+The package contains both production tools and Landscape reference scripts. This guide covers the Landscape reference scripts, which are shell scripts such as `signing_verification.sh` and `encryption_at_rest.sh`. See NVIDIA's documentation for the current set of reference scripts and each script's purpose. To run a production tool through Landscape, follow NVIDIA's deployment instructions for that tool.
 
 ## Add the script to Landscape
 
-1. In the Landscape web portal, go to **Scripts** > **Add script**.
-1. Copy the NVIDIA reference script into the script editor and complete the form, including its title and access group.
-1. Add attachments only when the NVIDIA script documentation requires them, and use the attachment names and paths expected by that script.
-1. Select **Add script**.
+For each script you plan to use:
 
-These steps use Landscape's normal script workflow. For more information about adding scripts, see {ref}`How to use remote script execution <how-to-web-portal-use-remote-script-execution>`.
+1. In the Landscape web portal, go to **Scripts** from the sidebar > **Add script**.
+1. Copy the NVIDIA reference script into the script editor and complete the form, including its title and access group.
+1. Add attachments only when the NVIDIA script documentation requires them, such as a configuration file that the script reads. Use the attachment names expected by that script.
+1. **Add script**
+
+If an NVIDIA script relies on an attached file, Landscape downloads its attachments to a temporary directory on the client when the script runs and sets the `LANDSCAPE_ATTACHMENTS` environment variable to that directory. NVIDIA scripts locate a bundled file such as `default.json` through this variable, for example `"$LANDSCAPE_ATTACHMENTS/default.json"` in Bash or `os.environ["LANDSCAPE_ATTACHMENTS"]` in Python, so add the file as an attachment using the name the script expects. For the full attachment behavior, see {ref}`explanation-remote-script-execution`.
+
+These steps use Landscape's normal script workflow. For more general information about using scripts in Landscape, see {ref}`How to use remote script execution <how-to-web-portal-use-remote-script-execution>`. You can also add and run scripts programmatically with the {ref}`Landscape REST API <how-to-rest-api-request>`.
 
 ## Run the script
 
-1. Identify the DGX Spark systems in Landscape. You can select instances directly or use the tags and access groups already used by your organization.
-1. Select the target instances and choose **Operations** > **Run script**.
-1. Select the NVIDIA reference script, choose the run-as user and time limit required by the NVIDIA script documentation, and select **Run**.
+1. Identify the DGX Spark systems in Landscape. You can select instances directly, or filter by the tag you applied during setup, such as `dgx-spark`, and by access group.
+1. Select the target instances, then **Operations** > **Run script**.
+1. Select the NVIDIA reference script, then set the run-as user and time limit required by the NVIDIA script documentation. NVIDIA's reference scripts typically run as `root`, and the run-as user must be one you authorized with `--script-users` during setup.
+1. Click **Run**.
 
 Start with one DGX Spark or a small test group before running a state-changing script across a larger group. Apply NVIDIA's change-control guidance for scripts that modify the system or initiate updates.
 
 ## Review the result
 
-Landscape creates an activity for each script execution. Monitor the activity from the **Activities** page or from the target instance's **Activities** tab. Select the activity to inspect its status and the output returned by the client.
+Landscape creates an {ref}`activity <explanation-activities>` for each script execution. Monitor the activities from the **Activities** page or from the target instance's **Activities** tab. Open the activity to inspect its status and the output returned by the client. Because each execution is recorded as an activity, you keep a central history of which reference scripts ran on your DGX Spark systems and what they returned.
 
-Landscape bounds returned script output using the client's `script_output_limit` configuration. A successful Landscape activity therefore does not mean that all NVIDIA evidence was transferred to Landscape. Use the output and local evidence according to the NVIDIA reference script's documentation, and contact NVIDIA for DGX-specific troubleshooting.
+The output that Landscape returns is limited by the client's `script_output_limit` configuration. NVIDIA's reference scripts are designed for this: they return a short summary and write their detailed evidence to files on the DGX Spark itself. A successful activity therefore doesn't mean that Landscape collected everything the script produced. To retrieve the detailed evidence, follow the NVIDIA reference script's documentation.
 
-For an optional recurring or post-enrollment workflow, supported self-hosted Landscape deployments can use {ref}`script profiles <how-to-web-portal-use-script-profiles>`. Script profiles are available only in self-hosted Landscape 25.04 and later; they are not the foundation of this guide.
+To run reference scripts automatically, on a recurring schedule, on a set date, or after an instance enrolls, self-hosted Landscape (25.04 and later) can use {ref}`script profiles <how-to-web-portal-use-script-profiles>`.
 
 ## Networking
 
-Use Landscape's {ref}`internal network requirements <reference-internal-network-requirements>` for Landscape Server and client connectivity. Remote script execution sends the script to Landscape Client for local execution; Landscape Server does not need to SSH into the DGX Spark for this workflow. This does not define or replace any separate NVIDIA hardware-management or site-specific network requirements.
+With remote script execution, Landscape sends the script to Landscape Client, which runs it locally on the DGX Spark. Landscape Server doesn't need SSH access to the DGX Spark for this workflow, so you don't need to open inbound SSH for it. For more information on the connectivity that Landscape Server and Landscape Client do require, see {ref}`internal network requirements <reference-internal-network-requirements>`.
+
+Note that NVIDIA may have separate network requirements for DGX Spark hardware management. Those are additional to Landscape's requirements.

--- a/docs/how-to-guides/nvidia-dgx-spark/set-up-nvidia-dgx-spark.md
+++ b/docs/how-to-guides/nvidia-dgx-spark/set-up-nvidia-dgx-spark.md
@@ -36,7 +36,7 @@ Register the DGX Spark with Landscape so that it appears in your Landscape accou
 
 1. In the Landscape web portal, accept the pending instance if your account requires manual acceptance, then confirm that the DGX Spark appears as a managed instance before continuing.
 
-For non-interactive registration, see {ref}`How to enable Landscape in the Ubuntu Pro Client <how-to-ubuntu-pro-enable-landscape>`.
+For non-interactive registration, see {ref}`How to enable Landscape in the Ubuntu Pro Client <how-to-ubuntu-pro-enable-landscape>`. To register several DGX Spark systems as part of provisioning them, you can also install and register Landscape Client with cloud-init. See {ref}`How to install Landscape Client <how-to-install-landscape-client>` for the Landscape Client settings, and [NVIDIA's custom installation documentation](https://docs.nvidia.com/dgx/dgx-spark/enterprise-custom-install.html) for the DGX Spark provisioning workflow.
 
 ## Enable remote script execution
 

--- a/docs/how-to-guides/nvidia-dgx-spark/set-up-nvidia-dgx-spark.md
+++ b/docs/how-to-guides/nvidia-dgx-spark/set-up-nvidia-dgx-spark.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Enroll an NVIDIA DGX Spark running DGX OS in Landscape and enable remote script execution for management."
+    description: "Register an NVIDIA DGX Spark running DGX OS with Landscape and enable remote script execution for management."
 ---
 
 (how-to-set-up-nvidia-dgx-spark)=
@@ -28,7 +28,7 @@ Choose the registration path that matches your Landscape deployment:
 - For **Landscape SaaS**, follow {ref}`How to create a SaaS account and register your first client <howto-create-saas-account>`. The `pro enable landscape` method installs Landscape Client and starts the registration wizard after Ubuntu Pro is attached.
 - For **self-hosted Landscape**, follow {ref}`How to install Landscape Client <how-to-install-landscape-client>` and {ref}`How to configure and register Landscape Client <how-to-configure-landscape-client>`. Provide the account name and Landscape Server URL for your deployment.
 
-NVIDIA's current enrollment example uses Ubuntu Pro and `pro enable landscape` with the self-hosted option set to **No**. That example is for Landscape SaaS. Use Canonical's self-hosted instructions when registering with your own Landscape Server.
+NVIDIA's current registration example uses Ubuntu Pro and `pro enable landscape` with the self-hosted option set to **No**. That example is for Landscape SaaS. Use Canonical's self-hosted instructions when registering with your own Landscape Server.
 
 When registering the DGX Spark, choose a descriptive computer title. After registration, an administrator may need to accept the pending computer in the Landscape web portal. Confirm that the DGX Spark appears as a managed instance before continuing.
 
@@ -36,7 +36,7 @@ When registering the DGX Spark, choose a descriptive computer title. After regis
 
 Enable the Landscape Client script execution plugin on the DGX Spark. Follow {ref}`Enable script execution <howto-heading-client-enable-script-execution>` in the Landscape Client configuration guide. That page documents the supported `landscape-config` options, including the system users allowed to run scripts, and the required client restart.
 
-Remote script execution is a Landscape capability. It does not require a DGX-specific client plugin or a separate NVIDIA enrollment mechanism.
+Remote script execution is a Landscape capability. It does not require a DGX-specific client plugin or a separate NVIDIA registration mechanism.
 
 ## Organize the DGX Spark systems
 

--- a/docs/how-to-guides/nvidia-dgx-spark/set-up-nvidia-dgx-spark.md
+++ b/docs/how-to-guides/nvidia-dgx-spark/set-up-nvidia-dgx-spark.md
@@ -7,49 +7,67 @@ myst:
 (how-to-set-up-nvidia-dgx-spark)=
 # Set up NVIDIA DGX Spark for Landscape management
 
-This guide covers bringing an existing NVIDIA DGX Spark under Landscape management. It uses the normal Landscape Client installation and registration workflow and leaves the system ready for NVIDIA's Landscape reference scripts.
+> See also: {ref}`Landscape and NVIDIA DGX Spark <explanation-related-tools-nvidia-dgx-spark>`.
 
-This guide does not cover installing or reinstalling DGX Spark. For recovery or custom installation, follow [NVIDIA's DGX Spark documentation](https://docs.nvidia.com/dgx/dgx-spark/), including its [system recovery](https://docs.nvidia.com/dgx/dgx-spark/system-recovery.html) guidance.
+This guide describes how to register an existing NVIDIA DGX Spark with Landscape and prepare the system to run NVIDIA's Landscape reference scripts.
+
+This guide doesn't cover installing or reinstalling DGX Spark, see [NVIDIA's DGX Spark documentation](https://docs.nvidia.com/dgx/dgx-spark/) for more information.
 
 ## Before you begin
 
 You need:
 
-- an existing DGX Spark running the DGX OS baseline documented by NVIDIA;
-- a Landscape SaaS account or access to a self-hosted Landscape account; and
-- permission to register a computer in that Landscape account.
-
-NVIDIA describes DGX OS as a customized Linux distribution based on Ubuntu and identifies it as the supported baseline for its DGX Spark enterprise manageability guidance. NVIDIA does not publish a separate Landscape Client version matrix for DGX Spark. Follow the current Landscape and Ubuntu Pro requirements for the client installation method you choose.
+- A DGX Spark running DGX OS
+- A {ref}`Landscape SaaS account <howto-create-saas-account>` or {ref}`self-hosted Landscape Server deployment <how-to-guides-landscape-installation-and-set-up-index>`
 
 ## Install and register Landscape Client
 
-Choose the registration path that matches your Landscape deployment:
+Register the DGX Spark with Landscape so that it appears in your Landscape account as a managed instance.
 
-- For **Landscape SaaS**, follow {ref}`How to create a SaaS account and register your first client <howto-create-saas-account>`. The `pro enable landscape` method installs Landscape Client and starts the registration wizard after Ubuntu Pro is attached.
-- For **self-hosted Landscape**, follow {ref}`How to install Landscape Client <how-to-install-landscape-client>` and {ref}`How to configure and register Landscape Client <how-to-configure-landscape-client>`. Provide the account name and Landscape Server URL for your deployment.
+1. On the DGX Spark, install and register Landscape Client:
 
-NVIDIA's current registration example uses Ubuntu Pro and `pro enable landscape` with the self-hosted option set to **No**. That example is for Landscape SaaS. Use Canonical's self-hosted instructions when registering with your own Landscape Server.
+   ```bash
+   sudo pro enable landscape
+   ```
 
-When registering the DGX Spark, choose a descriptive computer title. After registration, an administrator may need to accept the pending computer in the Landscape web portal. Confirm that the DGX Spark appears as a managed instance before continuing.
+   This command installs Landscape Client and starts the registration wizard.
+
+1. When prompted, provide your Landscape account name and a descriptive title. If you register the DGX Spark with a self-hosted Landscape Server, also provide the server URL.
+
+1. In the Landscape web portal, accept the pending instance if your account requires manual acceptance, then confirm that the DGX Spark appears as a managed instance before continuing.
+
+For non-interactive registration, see {ref}`How to enable Landscape in the Ubuntu Pro Client <how-to-ubuntu-pro-enable-landscape>`.
 
 ## Enable remote script execution
 
-Enable the Landscape Client script execution plugin on the DGX Spark. Follow {ref}`Enable script execution <howto-heading-client-enable-script-execution>` in the Landscape Client configuration guide. That page documents the supported `landscape-config` options, including the system users allowed to run scripts, and the required client restart.
+[NVIDIA provides Landscape reference scripts for selected DGX Spark management operations](https://docs.nvidia.com/dgx/dgx-spark/enterprise-fleet-lifecycle.html#canonical-landscape-reference-scripts-8). These scripts run locally on the DGX Spark through Landscape Client. Remote script execution is disabled by default, so you must enable the script execution plugin before you can run these scripts.
 
-Remote script execution is a Landscape capability. It does not require a DGX-specific client plugin or a separate NVIDIA registration mechanism.
+On the DGX Spark:
 
-## Organize the DGX Spark systems
+1. Enable the script execution plugin and authorize the system users that the scripts run as:
 
-You can apply an ordinary Landscape tag, such as `dgx-spark`, to identify these systems in a mixed fleet. Tags are optional and are chosen by your organization; Landscape does not create a special DGX Spark object type.
+   ```bash
+   sudo landscape-config \
+     --include-manager-plugins=ScriptExecution \
+     --script-users=root,landscape,nobody
+   ```
 
-For tag and access-group administration, see the {ref}`Landscape web portal documentation <how-to-guides-web-portal-index>`.
+   This allows the `root`, `landscape`, and `nobody` system users to run scripts. Adjust `--script-users` to match the run-as user required by the NVIDIA script you intend to use.
 
-## Verify the setup
+1. Restart Landscape Client to apply the change:
 
-Before using an NVIDIA reference script, confirm that:
+   ```bash
+   sudo systemctl restart landscape-client
+   ```
 
-1. The DGX Spark appears as a managed instance in Landscape.
-1. Landscape Client is running after the script execution configuration was applied.
-1. Remote script execution is enabled for the client and the intended run-as user is allowed by the client configuration.
+For other configuration options, see {ref}`Enable script execution <howto-heading-client-enable-script-execution>` in the Landscape Client configuration guide.
 
-When these conditions are met, continue to {ref}`Use NVIDIA DGX Spark management scripts with Landscape <how-to-manage-nvidia-dgx-spark>`.
+## Tag the DGX Spark systems
+
+{ref}`Tag <reference-terms-tags>` each DGX Spark with a consistent identifier, such as `dgx-spark`, so that you can target these systems as a group in a mixed fleet. A shared tag lets you run NVIDIA scripts against every DGX Spark at once and filter them from other Ubuntu instances in your Landscape account.
+
+Landscape manages a DGX Spark as an ordinary Ubuntu instance and doesn't automatically distinguish it from your other machines, so a tag is the recommended way to group these systems.
+
+## Next steps
+
+Now that the DGX Spark is registered and set up for remote script execution, continue to {ref}`Use NVIDIA DGX Spark management scripts with Landscape <how-to-manage-nvidia-dgx-spark>` to add and run NVIDIA's reference scripts on your DGX Spark systems.

--- a/docs/how-to-guides/nvidia-dgx-spark/set-up-nvidia-dgx-spark.md
+++ b/docs/how-to-guides/nvidia-dgx-spark/set-up-nvidia-dgx-spark.md
@@ -5,7 +5,7 @@ myst:
 ---
 
 (how-to-set-up-nvidia-dgx-spark)=
-# Set up NVIDIA DGX Spark for Landscape management
+# How to set up NVIDIA DGX Spark for Landscape management
 
 > See also: {ref}`Landscape and NVIDIA DGX Spark <explanation-related-tools-nvidia-dgx-spark>`.
 

--- a/docs/how-to-guides/nvidia-dgx-spark/set-up-nvidia-dgx-spark.md
+++ b/docs/how-to-guides/nvidia-dgx-spark/set-up-nvidia-dgx-spark.md
@@ -1,0 +1,55 @@
+---
+myst:
+  html_meta:
+    description: "Enroll an NVIDIA DGX Spark running DGX OS in Landscape and enable remote script execution for management."
+---
+
+(how-to-set-up-nvidia-dgx-spark)=
+# Set up NVIDIA DGX Spark for Landscape management
+
+This guide covers bringing an existing NVIDIA DGX Spark under Landscape management. It uses the normal Landscape Client installation and registration workflow and leaves the system ready for NVIDIA's Landscape reference scripts.
+
+This guide does not cover installing or reinstalling DGX Spark. For recovery or custom installation, follow [NVIDIA's DGX Spark documentation](https://docs.nvidia.com/dgx/dgx-spark/), including its [system recovery](https://docs.nvidia.com/dgx/dgx-spark/system-recovery.html) guidance.
+
+## Before you begin
+
+You need:
+
+- an existing DGX Spark running the DGX OS baseline documented by NVIDIA;
+- a Landscape SaaS account or access to a self-hosted Landscape account; and
+- permission to register a computer in that Landscape account.
+
+NVIDIA describes DGX OS as a customized Linux distribution based on Ubuntu and identifies it as the supported baseline for its DGX Spark enterprise manageability guidance. NVIDIA does not publish a separate Landscape Client version matrix for DGX Spark. Follow the current Landscape and Ubuntu Pro requirements for the client installation method you choose.
+
+## Install and register Landscape Client
+
+Choose the registration path that matches your Landscape deployment:
+
+- For **Landscape SaaS**, follow {ref}`How to create a SaaS account and register your first client <howto-create-saas-account>`. The `pro enable landscape` method installs Landscape Client and starts the registration wizard after Ubuntu Pro is attached.
+- For **self-hosted Landscape**, follow {ref}`How to install Landscape Client <how-to-install-landscape-client>` and {ref}`How to configure and register Landscape Client <how-to-configure-landscape-client>`. Provide the account name and Landscape Server URL for your deployment.
+
+NVIDIA's current enrollment example uses Ubuntu Pro and `pro enable landscape` with the self-hosted option set to **No**. That example is for Landscape SaaS. Use Canonical's self-hosted instructions when registering with your own Landscape Server.
+
+When registering the DGX Spark, choose a descriptive computer title. After registration, an administrator may need to accept the pending computer in the Landscape web portal. Confirm that the DGX Spark appears as a managed instance before continuing.
+
+## Enable remote script execution
+
+Enable the Landscape Client script execution plugin on the DGX Spark. Follow {ref}`Enable script execution <howto-heading-client-enable-script-execution>` in the Landscape Client configuration guide. That page documents the supported `landscape-config` options, including the system users allowed to run scripts, and the required client restart.
+
+Remote script execution is a Landscape capability. It does not require a DGX-specific client plugin or a separate NVIDIA enrollment mechanism.
+
+## Organize the DGX Spark systems
+
+You can apply an ordinary Landscape tag, such as `dgx-spark`, to identify these systems in a mixed fleet. Tags are optional and are chosen by your organization; Landscape does not create a special DGX Spark object type.
+
+For tag and access-group administration, see the {ref}`Landscape web portal documentation <how-to-guides-web-portal-index>`.
+
+## Verify the setup
+
+Before using an NVIDIA reference script, confirm that:
+
+1. The DGX Spark appears as a managed instance in Landscape.
+1. Landscape Client is running after the script execution configuration was applied.
+1. Remote script execution is enabled for the client and the intended run-as user is allowed by the client configuration.
+
+When these conditions are met, continue to {ref}`Use NVIDIA DGX Spark management scripts with Landscape <how-to-manage-nvidia-dgx-spark>`.


### PR DESCRIPTION
This PR is based on the content #293 (thanks to @rajannpatel for the original research and draft!! :balloon:), but with revisions and restructuring. 

The docs in this PR cover DGX Spark specifically, but are more tightly focused on the Landscape side of the workflow: registering the system, enabling remote script execution, and running NVIDIA's Landscape reference scripts.

**Main changes from the original PR**: I've removed the DGX provisioning part and NVIDIA scripts reference and linked to their documentation instead. This is because those are more relevant to NVIDIA and would be better maintained on their side. 

Other notable (but minor) changes to the information:
- Added Landscape Client installation with `sudo pro enable landscape`. The original PR assumed the client was already installed, and this matches NVIDIA's own enrollment steps.
- Separated NVIDIA's production tools from their Landscape reference scripts. The how-to covers the reference scripts, since those are the ones written for remote script execution.
- Added the interpreter requirement when adding a script, and how NVIDIA's scripts find attached files through `LANDSCAPE_ATTACHMENTS`.
- Removed the out-of-band management sections (Redfish, IPMI, BMC), since Landscape doesn't use those interfaces.