### PR TITLE
add API examples to debarchive API reference docs

### DIFF
--- a/docs/_static/openapi-overlay.yaml
+++ b/docs/_static/openapi-overlay.yaml
@@ -613,6 +613,6 @@ actions:
         name: operations/c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
         done: false
         metadata:
-          '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.PublishPublicationMetadata
+          '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskMetadata
         response:
           '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskCreatedResponse

--- a/docs/_static/openapi-overlay.yaml
+++ b/docs/_static/openapi-overlay.yaml
@@ -614,5 +614,10 @@ actions:
         done: false
         metadata:
           '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskMetadata
+          description: Publish mirror/snapshot (8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e)
+          operationId: c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
+          status: idle
+          progressPercent: 0
+          resource: publications/8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
         response:
           '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskCreatedResponse

--- a/docs/_static/openapi-overlay.yaml
+++ b/docs/_static/openapi-overlay.yaml
@@ -535,39 +535,3 @@ actions:
         done: false
         metadata:
           '@type': type.googleapis.com/debarchive.v1beta1.PublishPublicationMetadata
-  - target: $.paths['/v1beta1/publications:batchGet'].post.requestBody.content['application/json']
-    update:
-      example:
-        names:
-          - publications/8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
-          - publications/7c21ab3d-9f28-4b81-c4a5-7e9d3a8c1b5f
-  - target: $.paths['/v1beta1/publications:batchGet'].post.responses['200'].content['application/json']
-    update:
-      example:
-        publications:
-          - name: publications/8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
-            displayName: noble-updates-publication
-            publicationId: 8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
-            publicationTarget: publicationTargets/c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
-            source: mirrors/f27f353d-d580-4717-933b-53318e0bc9b2
-            distribution: noble-updates
-            label: Noble Updates Archive
-            origin: Ubuntu
-            architectures:
-              - amd64
-            acquireByHash: true
-            publishTime: "2025-06-02T04:15:00Z"
-            lastOperation: operations/c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
-          - name: publications/7c21ab3d-9f28-4b81-c4a5-7e9d3a8c1b5f
-            displayName: noble-security-publication
-            publicationId: 7c21ab3d-9f28-4b81-c4a5-7e9d3a8c1b5f
-            publicationTarget: publicationTargets/d8e5f9a0-2b3c-4d5e-7f8a-9b0c1d2e3f4a
-            source: mirrors/9d673b4c-d806-491e-ac9a-e797f03e2be5
-            distribution: noble-security
-            label: Noble Security Archive
-            origin: Ubuntu
-            architectures:
-              - amd64
-            acquireByHash: true
-            publishTime: "2025-06-02T03:45:00Z"
-            lastOperation: operations/d4e5f6a7-b8c9-4d5e-9f0a-1b2c3d4e5f6a

--- a/docs/_static/openapi-overlay.yaml
+++ b/docs/_static/openapi-overlay.yaml
@@ -16,6 +16,11 @@ actions:
         locals:
           - name: locals/8083cc90-2481-472e-89b6-d093a8d1c53c
             displayName: my-local-repository
+            comment: my local repository
+            defaultDistribution: noble-release-staging
+            defaultComponent: main
+            lastOperation: ""
+            lastImportTime: null
         nextPageToken: ""
   - target: $.paths['/v1beta1/locals'].post.requestBody.content['application/json']
     update:
@@ -83,18 +88,20 @@ actions:
         name: operations/4d02be5c-59d7-435c-ab78-d209347a722f
         done: false
         metadata:
-          '@type': type.googleapis.com/debarchive.v1beta1.TaskMetadata
+          '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskMetadata
           description: Import packages into local repo noble-release-staging (e3cf58b4-90d0-4f6b-b23b-3348c9aa2290)
           operationId: e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
           status: in progress
           progressPercent: 0
           resource: locals/e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
+        response:
+          '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskCreatedResponse
   - target: $.paths['/v1beta1/locals:batchGet'].post.requestBody.content['application/json']
     update:
       example:
         names:
-          - locals/noble-release
-          - locals/noble-release-staging
+          - locals/5554fd3c-beff-45ad-9884-c005d0d88584
+          - locals/e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
   - target: $.paths['/v1beta1/locals:batchGet'].post.responses['200'].content['application/json']
     update:
       example:
@@ -134,6 +141,15 @@ actions:
               - universe
               - multiverse
             mirrorType: UBUNTU_ARCHIVE
+            downloadInstaller: false
+            downloadSources: false
+            downloadUdebs: false
+            filter: ""
+            filterWithDeps: true
+            skipArchitectureCheck: false
+            skipComponentCheck: false
+            preserveSignatures: false
+            lastOperation: ""
           - name: mirrors/9d673b4c-d806-491e-ac9a-e797f03e2be5
             mirrorId: noble-security
             status: ACTIVE
@@ -146,6 +162,15 @@ actions:
               - main
               - restricted
             mirrorType: UBUNTU_ARCHIVE
+            downloadInstaller: false
+            downloadSources: false
+            downloadUdebs: false
+            filter: ""
+            filterWithDeps: true
+            skipArchitectureCheck: false
+            skipComponentCheck: false
+            preserveSignatures: false
+            lastOperation: ""
         nextPageToken: ""
   - target: $.paths['/v1beta1/mirrors'].post.requestBody.content['application/json']
     update:
@@ -177,6 +202,15 @@ actions:
           - universe
           - multiverse
         mirrorType: UBUNTU_ARCHIVE
+        downloadInstaller: false
+        downloadSources: false
+        downloadUdebs: false
+        filter: ""
+        filterWithDeps: true
+        skipArchitectureCheck: false
+        skipComponentCheck: false
+        preserveSignatures: false
+        lastOperation: ""
   - target: $.paths['/v1beta1/mirrors/{mirror}'].get.responses['200'].content['application/json']
     update:
       example:
@@ -195,6 +229,14 @@ actions:
           - universe
           - multiverse
         mirrorType: UBUNTU_ARCHIVE
+        downloadInstaller: false
+        downloadSources: false
+        downloadUdebs: false
+        filter: ""
+        filterWithDeps: true
+        skipArchitectureCheck: false
+        skipComponentCheck: false
+        preserveSignatures: false
         lastOperation: operations/22638757-5592-4b75-a3ee-2e27aee2a94a
   - target: $.paths['/v1beta1/mirrors/{mirror}'].patch.requestBody.content['application/json']
     update:
@@ -227,9 +269,16 @@ actions:
           - restricted
           - universe
           - multiverse
+        mirrorType: UBUNTU_ARCHIVE
+        downloadInstaller: false
+        downloadSources: false
+        downloadUdebs: false
         filter: Name (= nginx) | Name (= curl)
         filterWithDeps: true
-        mirrorType: UBUNTU_ARCHIVE
+        skipArchitectureCheck: false
+        skipComponentCheck: false
+        preserveSignatures: false
+        lastOperation: operations/22638757-5592-4b75-a3ee-2e27aee2a94a
   - target: $.paths['/v1beta1/mirrors/{mirror}/packages'].get.responses['200'].content['application/json']
     update:
       example:
@@ -249,12 +298,14 @@ actions:
         name: operations/faa0cd3c-d926-4698-aa35-52cc51ae2464
         done: false
         metadata:
-          '@type': type.googleapis.com/debarchive.v1beta1.TaskMetadata
+          '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskMetadata
           description: Syncing Mirror noble-updates (63844097-6b80-4aa1-8624-bfd419ea7a2b)
           operationId: faa0cd3c-d926-4698-aa35-52cc51ae2464
           status: in progress
           progressPercent: 0
           resource: mirrors/63844097-6b80-4aa1-8624-bfd419ea7a2b
+        response:
+          '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskCreatedResponse
   - target: $.paths['/v1beta1/mirrors:batchGet'].post.requestBody.content['application/json']
     update:
       example:
@@ -301,12 +352,14 @@ actions:
         name: operations/a1b2c3d4-e5f6-4a5b-6c7d-8e9f0a1b2c3d
         done: true
         metadata:
-          '@type': type.googleapis.com/debarchive.v1beta1.TaskMetadata
+          '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskMetadata
           description: Syncing Mirror noble-updates (f27f353d-d580-4717-933b-53318e0bc9b2)
           operationId: a1b2c3d4-e5f6-4a5b-6c7d-8e9f0a1b2c3d
           status: completed
           progressPercent: 100
           resource: mirrors/f27f353d-d580-4717-933b-53318e0bc9b2
+        response:
+          '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskCreatedResponse
   - target: $.paths['/v1beta1/operations:batchGet'].post.requestBody.content['application/json']
     update:
       example:
@@ -320,30 +373,36 @@ actions:
           - name: operations/a1b2c3d4-e5f6-4a5b-6c7d-8e9f0a1b2c3d
             done: true
             metadata:
-              '@type': type.googleapis.com/debarchive.v1beta1.TaskMetadata
+              '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskMetadata
               description: Syncing Mirror noble-updates (f27f353d-d580-4717-933b-53318e0bc9b2)
               operationId: a1b2c3d4-e5f6-4a5b-6c7d-8e9f0a1b2c3d
               status: completed
               progressPercent: 100
               resource: mirrors/f27f353d-d580-4717-933b-53318e0bc9b2
+            response:
+              '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskCreatedResponse
           - name: operations/b2c3d4e5-f6a7-4b5c-7d8e-9f0a1b2c3d4e
             done: false
             metadata:
-              '@type': type.googleapis.com/debarchive.v1beta1.TaskMetadata
+              '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskMetadata
               description: Import packages into local repo noble-release-staging (e3cf58b4-90d0-4f6b-b23b-3348c9aa2290)
               operationId: b2c3d4e5-f6a7-4b5c-7d8e-9f0a1b2c3d4e
               status: in progress
               progressPercent: 45
               resource: locals/e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
+            response:
+              '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskCreatedResponse
           - name: operations/c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
             done: true
             metadata:
-              '@type': type.googleapis.com/debarchive.v1beta1.TaskMetadata
+              '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskMetadata
               description: Syncing Mirror noble-security (9d673b4c-d806-491e-ac9a-e797f03e2be5)
               operationId: c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
               status: error
               progressPercent: 0
               resource: mirrors/9d673b4c-d806-491e-ac9a-e797f03e2be5
+            response:
+              '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskCreatedResponse
             error:
               details:
                 '@type': type.googleapis.com/google.rpc.DebugInfo
@@ -447,6 +506,11 @@ actions:
             architectures:
               - amd64
             acquireByHash: true
+            butAutomaticUpgrades: false
+            notAutomatic: false
+            multiDist: false
+            skipBz2: false
+            skipContents: false
             publishTime: "2025-06-02T04:15:00Z"
             lastOperation: operations/c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
         nextPageToken: ""
@@ -476,6 +540,12 @@ actions:
         architectures:
           - amd64
         acquireByHash: true
+        butAutomaticUpgrades: false
+        notAutomatic: false
+        multiDist: false
+        skipBz2: false
+        skipContents: false
+        lastOperation: ""
   - target: $.paths['/v1beta1/publications/{publication}'].get.responses['200'].content['application/json']
     update:
       example:
@@ -491,6 +561,11 @@ actions:
           - amd64
         acquireByHash: true
         publishTime: "2025-06-02T04:15:00Z"
+        butAutomaticUpgrades: false
+        notAutomatic: false
+        multiDist: false
+        skipBz2: false
+        skipContents: false
         lastOperation: operations/c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
   - target: $.paths['/v1beta1/publications/{publication}'].patch.requestBody.content['application/json']
     update:
@@ -519,7 +594,11 @@ actions:
         architectures:
           - amd64
         acquireByHash: true
+        butAutomaticUpgrades: false
         notAutomatic: true
+        multiDist: false
+        skipBz2: false
+        skipContents: false
         publishTime: "2025-06-02T04:15:00Z"
         lastOperation: operations/c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
   - target: $.paths['/v1beta1/publications/{publication}:publish'].post.requestBody.content['application/json']
@@ -534,4 +613,6 @@ actions:
         name: operations/c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
         done: false
         metadata:
-          '@type': type.googleapis.com/debarchive.v1beta1.PublishPublicationMetadata
+          '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.PublishPublicationMetadata
+        response:
+          '@type': type.googleapis.com/canonical.landscape.debarchive.v1beta1.TaskCreatedResponse

--- a/docs/_static/openapi-overlay.yaml
+++ b/docs/_static/openapi-overlay.yaml
@@ -14,6 +14,560 @@ actions:
     update:
       example:
         locals:
-          - name: locals/my-local
-            displayName: My local repository
+          - name: locals/8083cc90-2481-472e-89b6-d093a8d1c53c
+            displayName: my-local-repository
         nextPageToken: ""
+  - target: $.paths['/v1beta1/locals'].post.requestBody.content['application/json']
+    update:
+      example:
+        displayName: noble-release-staging
+        comment: Staging area for packages before promotion to the release pocket.
+        defaultDistribution: noble-release-staging
+        defaultComponent: main
+  - target: $.paths['/v1beta1/locals'].post.responses['200'].content['application/json']
+    update:
+      example:
+        name: locals/e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
+        localId: e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
+        displayName: noble-release-staging
+        comment: Staging area for packages before promotion to the release pocket.
+        defaultDistribution: noble-release-staging
+        defaultComponent: main
+        lastOperation: ""
+        lastImportTime: "0001-01-01T00:00:00Z"
+  - target: $.paths['/v1beta1/locals/{local}'].get.responses['200'].content['application/json']
+    update:
+      example:
+        name: locals/e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
+        localId: e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
+        displayName: noble-release-staging
+        comment: Staging area for packages before promotion to the release pocket.
+        defaultDistribution: noble-release-staging
+        defaultComponent: main
+        lastOperation: operations/5b77ac09-80ec-4fe8-912b-318a8f173661
+        lastImportTime: "2026-06-01T14:32:07Z"
+  - target: $.paths['/v1beta1/locals/{local}'].patch.requestBody.content['application/json']
+    update:
+      example:
+        displayName: noble-release-staging
+        comment: Staging area for packages before promotion to the release pocket, now covering security updates too.
+        defaultDistribution: noble-release-staging
+        defaultComponent: main
+  - target: $.paths['/v1beta1/locals/{local}'].patch.responses['200'].content['application/json']
+    update:
+      example:
+        name: locals/e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
+        localId: e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
+        displayName: noble-release-staging
+        comment: Staging area for packages before promotion to the release pocket, now covering security updates too.
+        defaultDistribution: noble-release-staging
+        defaultComponent: main
+        lastOperation: operations/5b77ac09-80ec-4fe8-912b-318a8f173661
+        lastImportTime: "2026-06-01T14:32:07Z"
+  - target: $.paths['/v1beta1/locals/{local}/packages'].get.responses['200'].content['application/json']
+    update:
+      example:
+        localPackages:
+          - nginx_1.24.0-2ubuntu7_amd64
+          - curl_8.5.0-2ubuntu10_amd64
+        nextPageToken: ""
+  - target: $.paths['/v1beta1/locals/{local}:importPackages'].post.requestBody.content['application/json']
+    update:
+      example:
+        name: locals/e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
+        url: https://example.com/archive/noble-release-staging/Packages
+        validateOnly: false
+  - target: $.paths['/v1beta1/locals/{local}:importPackages'].post.responses['200'].content['application/json']
+    update:
+      example:
+        name: operations/4d02be5c-59d7-435c-ab78-d209347a722f
+        done: false
+        metadata:
+          '@type': type.googleapis.com/debarchive.v1beta1.TaskMetadata
+          description: Import packages into local repo noble-release-staging (e3cf58b4-90d0-4f6b-b23b-3348c9aa2290)
+          operationId: e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
+          status: in progress
+          progressPercent: 0
+          resource: locals/e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
+  - target: $.paths['/v1beta1/locals:batchGet'].post.requestBody.content['application/json']
+    update:
+      example:
+        names:
+          - locals/noble-release
+          - locals/noble-release-staging
+  - target: $.paths['/v1beta1/locals:batchGet'].post.responses['200'].content['application/json']
+    update:
+      example:
+        locals:
+          - name: locals/5554fd3c-beff-45ad-9884-c005d0d88584
+            localId: 5554fd3c-beff-45ad-9884-c005d0d88584
+            displayName: noble-release
+            comment: Main release repository
+            defaultDistribution: noble
+            defaultComponent: main
+            lastOperation: operations/5b77ac09-80ec-4fe8-912b-318a8f173661
+            lastImportTime: "2026-05-20T09:15:00Z"
+          - name: locals/e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
+            localId: e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
+            displayName: noble-release-staging
+            comment: Staging area for packages before promotion to the release pocket.
+            defaultDistribution: noble-release-staging
+            defaultComponent: main
+            lastOperation: operations/e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
+            lastImportTime: "2026-06-01T14:32:07Z"
+  - target: $.paths['/v1beta1/mirrors'].get.responses['200'].content['application/json']
+    update:
+      example:
+        mirrors:
+          - name: mirrors/f27f353d-d580-4717-933b-53318e0bc9b2
+            mirrorId: noble-updates
+            status: ACTIVE
+            lastDownloadDate: "2026-06-02T03:00:00Z"
+            displayName: noble-updates
+            archiveRoot: http://archive.ubuntu.com/ubuntu
+            distribution: noble-updates
+            architectures:
+              - amd64
+            components:
+              - main
+              - restricted
+              - universe
+              - multiverse
+            mirrorType: UBUNTU_ARCHIVE
+          - name: mirrors/9d673b4c-d806-491e-ac9a-e797f03e2be5
+            mirrorId: noble-security
+            status: ACTIVE
+            displayName: noble-security
+            archiveRoot: http://security.ubuntu.com/ubuntu
+            distribution: noble-security
+            architectures:
+              - amd64
+            components:
+              - main
+              - restricted
+            mirrorType: UBUNTU_ARCHIVE
+        nextPageToken: ""
+  - target: $.paths['/v1beta1/mirrors'].post.requestBody.content['application/json']
+    update:
+      example:
+        displayName: noble-updates
+        archiveRoot: http://archive.ubuntu.com/ubuntu
+        distribution: noble-updates
+        architectures:
+          - amd64
+        components:
+          - main
+          - restricted
+          - universe
+          - multiverse
+        mirrorType: UBUNTU_ARCHIVE
+  - target: $.paths['/v1beta1/mirrors'].post.responses['200'].content['application/json']
+    update:
+      example:
+        name: mirrors/2575bc92-e5a6-4ea0-9cda-ffd66dedcb7d
+        mirrorId: 2575bc92-e5a6-4ea0-9cda-ffd66dedcb7d
+        displayName: noble-updates
+        archiveRoot: http://archive.ubuntu.com/ubuntu
+        distribution: noble-updates
+        architectures:
+          - amd64
+        components:
+          - main
+          - restricted
+          - universe
+          - multiverse
+        mirrorType: UBUNTU_ARCHIVE
+  - target: $.paths['/v1beta1/mirrors/{mirror}'].get.responses['200'].content['application/json']
+    update:
+      example:
+        name: mirrors/e5b6dfe9-bfd3-4056-abab-d685e9748c32
+        mirrorId: e5b6dfe9-bfd3-4056-abab-d685e9748c32
+        status: ACTIVE
+        lastDownloadDate: "2026-06-02T03:00:00Z"
+        displayName: noble-updates
+        archiveRoot: http://archive.ubuntu.com/ubuntu
+        distribution: noble-updates
+        architectures:
+          - amd64
+        components:
+          - main
+          - restricted
+          - universe
+          - multiverse
+        mirrorType: UBUNTU_ARCHIVE
+        lastOperation: operations/22638757-5592-4b75-a3ee-2e27aee2a94a
+  - target: $.paths['/v1beta1/mirrors/{mirror}'].patch.requestBody.content['application/json']
+    update:
+      example:
+        displayName: noble-updates
+        archiveRoot: http://archive.ubuntu.com/ubuntu
+        distribution: noble-updates
+        architectures:
+          - amd64
+        components:
+          - main
+          - restricted
+          - universe
+          - multiverse
+        filter: Name (= nginx) | Name (= curl)
+        filterWithDeps: true
+  - target: $.paths['/v1beta1/mirrors/{mirror}'].patch.responses['200'].content['application/json']
+    update:
+      example:
+        name: mirrors/42337189-af1b-49fe-853e-d63264050656
+        mirrorId: 42337189-af1b-49fe-853e-d63264050656
+        status: ACTIVE
+        displayName: noble-updates
+        archiveRoot: http://archive.ubuntu.com/ubuntu
+        distribution: noble-updates
+        architectures:
+          - amd64
+        components:
+          - main
+          - restricted
+          - universe
+          - multiverse
+        filter: Name (= nginx) | Name (= curl)
+        filterWithDeps: true
+        mirrorType: UBUNTU_ARCHIVE
+  - target: $.paths['/v1beta1/mirrors/{mirror}/packages'].get.responses['200'].content['application/json']
+    update:
+      example:
+        mirrorPackages:
+          - nginx_1.24.0-2ubuntu7_amd64
+          - openssl_3.0.13-0ubuntu3_amd64
+        nextPageToken: ""
+  - target: $.paths['/v1beta1/mirrors/{mirror}:sync'].post.requestBody.content['application/json']
+    update:
+      example:
+        name: mirrors/0e341898-20fe-4be0-a6e5-5008d72ec932
+        forceUpdate: false
+        ignoreChecksums: false
+  - target: $.paths['/v1beta1/mirrors/{mirror}:sync'].post.responses['200'].content['application/json']
+    update:
+      example:
+        name: operations/faa0cd3c-d926-4698-aa35-52cc51ae2464
+        done: false
+        metadata:
+          '@type': type.googleapis.com/debarchive.v1beta1.TaskMetadata
+          description: Syncing Mirror noble-updates (63844097-6b80-4aa1-8624-bfd419ea7a2b)
+          operationId: faa0cd3c-d926-4698-aa35-52cc51ae2464
+          status: in progress
+          progressPercent: 0
+          resource: mirrors/63844097-6b80-4aa1-8624-bfd419ea7a2b
+  - target: $.paths['/v1beta1/mirrors:batchGet'].post.requestBody.content['application/json']
+    update:
+      example:
+        names:
+          - mirrors/f27f353d-d580-4717-933b-53318e0bc9b2
+          - mirrors/9d673b4c-d806-491e-ac9a-e797f03e2be5
+  - target: $.paths['/v1beta1/mirrors:batchGet'].post.responses['200'].content['application/json']
+    update:
+      example:
+        mirrors:
+          - name: mirrors/f27f353d-d580-4717-933b-53318e0bc9b2
+            mirrorId: f27f353d-d580-4717-933b-53318e0bc9b2
+            status: ACTIVE
+            lastDownloadDate: "2026-06-02T03:00:00Z"
+            displayName: noble-updates
+            archiveRoot: http://archive.ubuntu.com/ubuntu
+            distribution: noble-updates
+            architectures:
+              - amd64
+            components:
+              - main
+              - restricted
+              - universe
+              - multiverse
+            mirrorType: UBUNTU_ARCHIVE
+            lastOperation: operations/22638757-5592-4b75-a3ee-2e27aee2a94a
+          - name: mirrors/9d673b4c-d806-491e-ac9a-e797f03e2be5
+            mirrorId: 9d673b4c-d806-491e-ac9a-e797f03e2be5
+            status: ACTIVE
+            lastDownloadDate: "2026-06-02T02:30:00Z"
+            displayName: noble-security
+            archiveRoot: http://security.ubuntu.com/ubuntu
+            distribution: noble-security
+            architectures:
+              - amd64
+            components:
+              - main
+              - restricted
+            mirrorType: UBUNTU_ARCHIVE
+            lastOperation: operations/15729183-9f28-4b81-c4a5-7e9d3a8c1b5f
+  - target: $.paths['/v1beta1/operations/{operation}'].get.responses['200'].content['application/json']
+    update:
+      example:
+        name: operations/a1b2c3d4-e5f6-4a5b-6c7d-8e9f0a1b2c3d
+        done: true
+        metadata:
+          '@type': type.googleapis.com/debarchive.v1beta1.TaskMetadata
+          description: Syncing Mirror noble-updates (f27f353d-d580-4717-933b-53318e0bc9b2)
+          operationId: a1b2c3d4-e5f6-4a5b-6c7d-8e9f0a1b2c3d
+          status: completed
+          progressPercent: 100
+          resource: mirrors/f27f353d-d580-4717-933b-53318e0bc9b2
+  - target: $.paths['/v1beta1/operations:batchGet'].post.requestBody.content['application/json']
+    update:
+      example:
+        names:
+          - operations/a1b2c3d4-e5f6-4a5b-6c7d-8e9f0a1b2c3d
+          - operations/b2c3d4e5-f6a7-4b5c-7d8e-9f0a1b2c3d4e
+  - target: $.paths['/v1beta1/operations:batchGet'].post.responses['200'].content['application/json']
+    update:
+      example:
+        operations:
+          - name: operations/a1b2c3d4-e5f6-4a5b-6c7d-8e9f0a1b2c3d
+            done: true
+            metadata:
+              '@type': type.googleapis.com/debarchive.v1beta1.TaskMetadata
+              description: Syncing Mirror noble-updates (f27f353d-d580-4717-933b-53318e0bc9b2)
+              operationId: a1b2c3d4-e5f6-4a5b-6c7d-8e9f0a1b2c3d
+              status: completed
+              progressPercent: 100
+              resource: mirrors/f27f353d-d580-4717-933b-53318e0bc9b2
+          - name: operations/b2c3d4e5-f6a7-4b5c-7d8e-9f0a1b2c3d4e
+            done: false
+            metadata:
+              '@type': type.googleapis.com/debarchive.v1beta1.TaskMetadata
+              description: Import packages into local repo noble-release-staging (e3cf58b4-90d0-4f6b-b23b-3348c9aa2290)
+              operationId: b2c3d4e5-f6a7-4b5c-7d8e-9f0a1b2c3d4e
+              status: in progress
+              progressPercent: 45
+              resource: locals/e3cf58b4-90d0-4f6b-b23b-3348c9aa2290
+          - name: operations/c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
+            done: true
+            metadata:
+              '@type': type.googleapis.com/debarchive.v1beta1.TaskMetadata
+              description: Syncing Mirror noble-security (9d673b4c-d806-491e-ac9a-e797f03e2be5)
+              operationId: c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
+              status: error
+              progressPercent: 0
+              resource: mirrors/9d673b4c-d806-491e-ac9a-e797f03e2be5
+            error:
+              details:
+                '@type': type.googleapis.com/google.rpc.DebugInfo
+                detail: Task operation error logs
+                stackEntries:
+                  - "mirror 9d673b4c-d806-491e-ac9a-e797f03e2be5: unable to update: server returned 404 Not Found"
+  - target: $.paths['/v1beta1/publicationTargets'].get.responses['200'].content['application/json']
+    update:
+      example:
+        publicationTargets:
+          - name: publicationTargets/c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+            publicationTargetId: c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+            displayName: noble-local-archive
+            filesystem:
+              path: /srv/published-repos/noble-archive
+              linkMethod: HARDLINK
+          - name: publicationTargets/d8e5f9a0-2b3c-4d5e-7f8a-9b0c1d2e3f4a
+            publicationTargetId: d8e5f9a0-2b3c-4d5e-7f8a-9b0c1d2e3f4a
+            displayName: noble-s3-mirror
+            s3:
+              region: us-east-1
+              bucket: landscape-noble-archive
+              prefix: ubuntu
+        nextPageToken: ""
+  - target: $.paths['/v1beta1/publicationTargets'].post.requestBody.content['application/json']
+    update:
+      example:
+        displayName: noble-local-archive
+        filesystem:
+          path: /srv/published-repos/noble-archive
+          linkMethod: HARDLINK
+  - target: $.paths['/v1beta1/publicationTargets'].post.responses['200'].content['application/json']
+    update:
+      example:
+        name: publicationTargets/c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+        publicationTargetId: c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+        displayName: noble-local-archive
+        filesystem:
+          path: /srv/published-repos/noble-archive
+          linkMethod: HARDLINK
+  - target: $.paths['/v1beta1/publicationTargets/{publicationTarget}'].get.responses['200'].content['application/json']
+    update:
+      example:
+        name: publicationTargets/c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+        publicationTargetId: c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+        displayName: noble-local-archive
+        filesystem:
+          path: /srv/published-repos/noble-archive
+          linkMethod: HARDLINK
+  - target: $.paths['/v1beta1/publicationTargets/{publicationTarget}'].patch.requestBody.content['application/json']
+    update:
+      example:
+        displayName: noble-local-archive
+        filesystem:
+          path: /srv/published-repos/noble-archive-v2
+          linkMethod: HARDLINK
+  - target: $.paths['/v1beta1/publicationTargets/{publicationTarget}'].patch.responses['200'].content['application/json']
+    update:
+      example:
+        name: publicationTargets/c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+        publicationTargetId: c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+        displayName: noble-local-archive
+        filesystem:
+          path: /srv/published-repos/noble-archive-v2
+          linkMethod: HARDLINK
+  - target: $.paths['/v1beta1/publicationTargets:batchGet'].post.requestBody.content['application/json']
+    update:
+      example:
+        names:
+          - publicationTargets/c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+          - publicationTargets/d8e5f9a0-2b3c-4d5e-7f8a-9b0c1d2e3f4a
+  - target: $.paths['/v1beta1/publicationTargets:batchGet'].post.responses['200'].content['application/json']
+    update:
+      example:
+        publicationTargets:
+          - name: publicationTargets/c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+            publicationTargetId: c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+            displayName: noble-local-archive
+            filesystem:
+              path: /srv/published-repos/noble-archive
+              linkMethod: HARDLINK
+          - name: publicationTargets/d8e5f9a0-2b3c-4d5e-7f8a-9b0c1d2e3f4a
+            publicationTargetId: d8e5f9a0-2b3c-4d5e-7f8a-9b0c1d2e3f4a
+            displayName: noble-s3-mirror
+            s3:
+              region: us-east-1
+              bucket: landscape-noble-archive
+              prefix: ubuntu
+  - target: $.paths['/v1beta1/publications'].get.responses['200'].content['application/json']
+    update:
+      example:
+        publications:
+          - name: publications/8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
+            displayName: noble-updates-publication
+            publicationId: 8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
+            publicationTarget: publicationTargets/c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+            source: mirrors/f27f353d-d580-4717-933b-53318e0bc9b2
+            distribution: noble-updates
+            label: Noble Updates Archive
+            origin: Ubuntu
+            architectures:
+              - amd64
+            acquireByHash: true
+            publishTime: "2025-06-02T04:15:00Z"
+            lastOperation: operations/c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
+        nextPageToken: ""
+  - target: $.paths['/v1beta1/publications'].post.requestBody.content['application/json']
+    update:
+      example:
+        displayName: noble-updates-publication
+        publicationTarget: publicationTargets/c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+        source: mirrors/f27f353d-d580-4717-933b-53318e0bc9b2
+        distribution: noble-updates
+        label: Noble Updates Archive
+        origin: Ubuntu
+        architectures:
+          - amd64
+        acquireByHash: true
+  - target: $.paths['/v1beta1/publications'].post.responses['200'].content['application/json']
+    update:
+      example:
+        name: publications/8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
+        displayName: noble-updates-publication
+        publicationId: 8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
+        publicationTarget: publicationTargets/c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+        source: mirrors/f27f353d-d580-4717-933b-53318e0bc9b2
+        distribution: noble-updates
+        label: Noble Updates Archive
+        origin: Ubuntu
+        architectures:
+          - amd64
+        acquireByHash: true
+  - target: $.paths['/v1beta1/publications/{publication}'].get.responses['200'].content['application/json']
+    update:
+      example:
+        name: publications/8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
+        displayName: noble-updates-publication
+        publicationId: 8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
+        publicationTarget: publicationTargets/c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+        source: mirrors/f27f353d-d580-4717-933b-53318e0bc9b2
+        distribution: noble-updates
+        label: Noble Updates Archive
+        origin: Ubuntu
+        architectures:
+          - amd64
+        acquireByHash: true
+        publishTime: "2025-06-02T04:15:00Z"
+        lastOperation: operations/c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
+  - target: $.paths['/v1beta1/publications/{publication}'].patch.requestBody.content['application/json']
+    update:
+      example:
+        displayName: noble-updates-publication
+        publicationTarget: publicationTargets/c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+        source: mirrors/f27f353d-d580-4717-933b-53318e0bc9b2
+        distribution: noble-updates
+        label: Noble Updates Archive
+        origin: Ubuntu
+        architectures:
+          - amd64
+        acquireByHash: true
+        notAutomatic: true
+  - target: $.paths['/v1beta1/publications/{publication}'].patch.responses['200'].content['application/json']
+    update:
+      example:
+        name: publications/8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
+        displayName: noble-updates-publication
+        publicationId: 8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
+        publicationTarget: publicationTargets/c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+        source: mirrors/f27f353d-d580-4717-933b-53318e0bc9b2
+        distribution: noble-updates
+        label: Noble Updates Archive
+        origin: Ubuntu
+        architectures:
+          - amd64
+        acquireByHash: true
+        notAutomatic: true
+        publishTime: "2025-06-02T04:15:00Z"
+        lastOperation: operations/c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
+  - target: $.paths['/v1beta1/publications/{publication}:publish'].post.requestBody.content['application/json']
+    update:
+      example:
+        name: publications/8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
+        forceOverwrite: false
+        forceCleanup: false
+  - target: $.paths['/v1beta1/publications/{publication}:publish'].post.responses['200'].content['application/json']
+    update:
+      example:
+        name: operations/c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
+        done: false
+        metadata:
+          '@type': type.googleapis.com/debarchive.v1beta1.PublishPublicationMetadata
+  - target: $.paths['/v1beta1/publications:batchGet'].post.requestBody.content['application/json']
+    update:
+      example:
+        names:
+          - publications/8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
+          - publications/7c21ab3d-9f28-4b81-c4a5-7e9d3a8c1b5f
+  - target: $.paths['/v1beta1/publications:batchGet'].post.responses['200'].content['application/json']
+    update:
+      example:
+        publications:
+          - name: publications/8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
+            displayName: noble-updates-publication
+            publicationId: 8f14e045-7d3b-4a0d-8f7c-1e0c9a2b3d4e
+            publicationTarget: publicationTargets/c7d4e8f9-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+            source: mirrors/f27f353d-d580-4717-933b-53318e0bc9b2
+            distribution: noble-updates
+            label: Noble Updates Archive
+            origin: Ubuntu
+            architectures:
+              - amd64
+            acquireByHash: true
+            publishTime: "2025-06-02T04:15:00Z"
+            lastOperation: operations/c3d4e5f6-a7b8-4c5d-8e9f-0a1b2c3d4e5f
+          - name: publications/7c21ab3d-9f28-4b81-c4a5-7e9d3a8c1b5f
+            displayName: noble-security-publication
+            publicationId: 7c21ab3d-9f28-4b81-c4a5-7e9d3a8c1b5f
+            publicationTarget: publicationTargets/d8e5f9a0-2b3c-4d5e-7f8a-9b0c1d2e3f4a
+            source: mirrors/9d673b4c-d806-491e-ac9a-e797f03e2be5
+            distribution: noble-security
+            label: Noble Security Archive
+            origin: Ubuntu
+            architectures:
+              - amd64
+            acquireByHash: true
+            publishTime: "2025-06-02T03:45:00Z"
+            lastOperation: operations/d4e5f6a7-b8c9-4d5e-9f0a-1b2c3d4e5f6a


### PR DESCRIPTION
Adds realistic examples for the debarchive API reference documentation using the OpenAPI overlay YAML.

Please check to make sure things look okay, perhaps make some test requests to ensure that the requests are valid.