### PR TITLE
fix: add note about min_install being set, and mention that ouputs need to be set to view them, use right name for pg interface, mention that old HAProxy is still supported

### DIFF
--- a/docs/explanation/charm/charm-compatibility.md
+++ b/docs/explanation/charm/charm-compatibility.md
@@ -58,15 +58,15 @@ For migration from older deployments to 26.04, see {ref}`how-to-migrate-to-26-04
 
 | Charm                         | Landscape 26.04 LTS                                                  | Before 26.04                                    |
 | ----------------------------- | -------------------------------------------------------------------- | ----------------------------------------------- |
-| **PostgreSQL**                | Required (PostgreSQL 14+, `postgresql_client` interface)             | Required (PostgreSQL 14, `pgsql` interface)     |
+| **PostgreSQL**                | Required (PostgreSQL 14+, `postgresql_client` interface)             | Required (PostgreSQL 14, `pgsql` interface, deprecated)     |
 | **RabbitMQ Server**           | Required                                                             | Required                                        |
-| **HAProxy**                   | Required (`2.8/x`, `haproxy-route` interface recommended; `latest/x`, `reverseproxy` interface still supported but deprecated) | Required (`latest/x`, `reverseproxy` interface) |
+| **HAProxy**                   | Required (`2.8/x`, `haproxy-route` interface recommended; `latest/x`, `reverseproxy` interface (available for backwards compatibility but deprecated)) | Required (`latest/x`, `reverseproxy` interface) |
 | **TLS Certificates Provider** | Required (integrated with HAProxy, e.g., `self-signed-certificates`) | Not used                                        |
 | **landscape-debarchive**      | Required (Debarchive repository management)                          | Not available                                   |
 | **landscape-task-handler**    | Required (task processing)                                           | Not available                                   |
 
 ```{note}
-The legacy `pgsql` PostgreSQL interface and the legacy `reverseproxy` HAProxy interface are both still supported for backwards compatibility, but are deprecated. Support for both will be removed in Landscape 26.10. Migrate to the modern `postgresql_client` and `haproxy-route` interfaces; see {ref}`how-to-migrate-to-26-04-charm`.
+The legacy `pgsql` PostgreSQL interface and the legacy `reverseproxy` HAProxy interface are both still available for backwards compatibility, but are deprecated. Support for both will be removed in Landscape 26.10. Migrate to the modern `postgresql_client` and `haproxy-route` interfaces; see {ref}`how-to-migrate-to-26-04-charm`.
 ```
 
 ## TLS certificates charm interface
@@ -115,7 +115,7 @@ The relationship between Landscape Server and HAProxy varies significantly betwe
 - Cannot be integrated with the `2.8/x` channels of the HAProxy charm
 
 ```{note}
-The legacy `reverseproxy` interface (`website` relation) is still supported for backwards compatibility, but is deprecated. Support will be removed in Landscape 26.10. See {ref}`how-to-migrate-to-26-04-charm` to migrate to the `haproxy-route` interface.
+The legacy `reverseproxy` interface (`website` relation) is still available for backwards compatibility, but is deprecated. Support will be removed in Landscape 26.10. See {ref}`how-to-migrate-to-26-04-charm` to migrate to the `haproxy-route` interface.
 ```
 
 **LBaaS (Load Balancer as a Service) - cross-model HAProxy:**
@@ -143,7 +143,7 @@ PostgreSQL charm compatibility varies by Landscape Server version:
 - Cannot use PostgreSQL 16 due to interface incompatibility
 
 ```{note}
-The legacy `pgsql` interface (`db` relation endpoint) is still supported for backwards compatibility, but is deprecated. Support will be removed in Landscape 26.10. See {ref}`how-to-migrate-to-26-04-charm` to migrate to the `postgresql_client` interface.
+The legacy `pgsql` interface (`db` relation endpoint) is still available for backwards compatibility, but is deprecated. Support will be removed in Landscape 26.10. See {ref}`how-to-migrate-to-26-04-charm` to migrate to the `postgresql_client` interface.
 ```
 
 - [Charmed PostgreSQL VM on Charmhub](https://charmhub.io/postgresql)

--- a/docs/explanation/charm/charm-compatibility.md
+++ b/docs/explanation/charm/charm-compatibility.md
@@ -60,10 +60,14 @@ For migration from older deployments to 26.04, see {ref}`how-to-migrate-to-26-04
 | ----------------------------- | -------------------------------------------------------------------- | ----------------------------------------------- |
 | **PostgreSQL**                | Required (PostgreSQL 14+, `postgresql_client` interface)             | Required (PostgreSQL 14, `pgsql` interface)     |
 | **RabbitMQ Server**           | Required                                                             | Required                                        |
-| **HAProxy**                   | Required (`2.8/x`, `haproxy-route` interface)                        | Required (`latest/x`, `reverseproxy` interface) |
+| **HAProxy**                   | Required (`2.8/x`, `haproxy-route` interface recommended; `latest/x`, `reverseproxy` interface still supported but deprecated) | Required (`latest/x`, `reverseproxy` interface) |
 | **TLS Certificates Provider** | Required (integrated with HAProxy, e.g., `self-signed-certificates`) | Not used                                        |
 | **landscape-debarchive**      | Required (Debarchive repository management)                          | Not available                                   |
 | **landscape-task-handler**    | Required (task processing)                                           | Not available                                   |
+
+```{note}
+The legacy `pgsql` PostgreSQL interface and the legacy `reverseproxy` HAProxy interface are both still supported for backwards compatibility, but are deprecated. Support for both will be removed in Landscape 26.10. Migrate to the modern `postgresql_client` and `haproxy-route` interfaces; see {ref}`how-to-migrate-to-26-04-charm`.
+```
 
 ## TLS certificates charm interface
 
@@ -100,15 +104,19 @@ Landscape Server can still consume a cross-model offer from a K8s charm since cr
 The relationship between Landscape Server and HAProxy varies significantly between Landscape versions:
 
 **Landscape 26.04 LTS:**
-- Requires the HAProxy charm at `2.8/stable`
+- Uses the HAProxy charm at `2.8/stable` for new deployments
 - Integrates via 8 `haproxy-route` relation endpoints directly from landscape-server to haproxy
 - HAProxy handles TLS termination and load balancing
-- Cannot be integrated with the `latest/x` channels of the HAProxy charm (different interface)
+- Can still integrate with the `latest/x` HAProxy charm via the deprecated `website`/`reverseproxy` relation for backwards compatibility (see note below)
 
 **Before 26.04:**
 - Requires the external HAProxy charm at `latest/x`
 - Integrates via the `reverseproxy` interface: `landscape-server:website` → `haproxy:reverseproxy`
 - Cannot be integrated with the `2.8/x` channels of the HAProxy charm
+
+```{note}
+The legacy `reverseproxy` interface (`website` relation) is still supported for backwards compatibility, but is deprecated. Support will be removed in Landscape 26.10. See {ref}`how-to-migrate-to-26-04-charm` to migrate to the `haproxy-route` interface.
+```
 
 **LBaaS (Load Balancer as a Service) - cross-model HAProxy:**
 - Deploy HAProxy in a separate Juju model and use cross-model relations
@@ -133,6 +141,10 @@ PostgreSQL charm compatibility varies by Landscape Server version:
 - Compatible with PostgreSQL 14 using the legacy `pgsql` interface
 - Landscape Server integrates using the `db` relation endpoint: `landscape-server:db` → `postgresql:db-admin`
 - Cannot use PostgreSQL 16 due to interface incompatibility
+
+```{note}
+The legacy `pgsql` interface (`db` relation endpoint) is still supported for backwards compatibility, but is deprecated. Support will be removed in Landscape 26.10. See {ref}`how-to-migrate-to-26-04-charm` to migrate to the `postgresql_client` interface.
+```
 
 - [Charmed PostgreSQL VM on Charmhub](https://charmhub.io/postgresql)
 

--- a/docs/explanation/charm/charm-compatibility.md
+++ b/docs/explanation/charm/charm-compatibility.md
@@ -37,7 +37,7 @@ The Landscape Server charm supports two deployment architectures:
 
 **Landscape 26.04 LTS (recommended):**
 - External HAProxy charm (`2.8/stable`) for load balancing, using the `haproxy-route` interface
-- PostgreSQL 14+ with modern `database` interface
+- PostgreSQL 14+ with modern `postgresql_client` interface
 - TLS certificates via a `tls-certificates` interface provider integrated with HAProxy
 - `landscape-debarchive` charm for Debarchive repository management
 - `landscape-task-handler` charm for task processing
@@ -56,13 +56,13 @@ For migration from older deployments to 26.04, see {ref}`how-to-migrate-to-26-04
 
 ## Required integrations by version
 
-| Charm                         | Landscape 26.04 LTS                                            | Before 26.04                                    |
+| Charm                         | Landscape 26.04 LTS                                                  | Before 26.04                                    |
 | ----------------------------- | -------------------------------------------------------------------- | ----------------------------------------------- |
-| **PostgreSQL**                | Required (PostgreSQL 14+, `database` interface)                      | Required (PostgreSQL 14, `pgsql` interface)     |
+| **PostgreSQL**                | Required (PostgreSQL 14+, `postgresql_client` interface)             | Required (PostgreSQL 14, `pgsql` interface)     |
 | **RabbitMQ Server**           | Required                                                             | Required                                        |
 | **HAProxy**                   | Required (`2.8/x`, `haproxy-route` interface)                        | Required (`latest/x`, `reverseproxy` interface) |
 | **TLS Certificates Provider** | Required (integrated with HAProxy, e.g., `self-signed-certificates`) | Not used                                        |
-| **landscape-debarchive**      | Required (Debarchive repository management)                         | Not available                                   |
+| **landscape-debarchive**      | Required (Debarchive repository management)                          | Not available                                   |
 | **landscape-task-handler**    | Required (task processing)                                           | Not available                                   |
 
 ## TLS certificates charm interface
@@ -124,7 +124,7 @@ For migrating from older deployments to the new HAProxy architecture, see {ref}`
 PostgreSQL charm compatibility varies by Landscape Server version:
 
 **Landscape 26.04 LTS:**
-- Compatible with PostgreSQL 14+ using the modern `database` interface
+- Compatible with PostgreSQL 14+ using the modern `postgresql_client` interface
 - Landscape Server integrates using the `database` relation endpoint: `landscape-server:database` → `postgresql:database`
 - It is recommended to use PostgreSQL 16 for new deployments
 - Supports [PgBouncer](https://charmhub.io/pgbouncer) as a connection pooler via the `database` relation endpoint; see {ref}`explanation-pgbouncer-integration`

--- a/docs/how-to-guides/landscape-installation-and-set-up/terraform-juju-deployment.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/terraform-juju-deployment.md
@@ -77,7 +77,7 @@ cp terraform.tfvars.modern terraform.tfvars   # or terraform.tfvars.example for 
 Open `terraform.tfvars` and adjust it for your deployment, at minimum setting `landscape_server.config.root_url` to your own domain name. `landscape_debarchive` and `landscape_task_handler` are both required and should not be set to `null`; when set, the module automatically integrates both with `landscape_server`, `postgresql`, `tls_certificates`, and, for the task handler's gRPC route, `haproxy`.
 
 ```{warning}
-Setting `min_install = "true"` cofigures the deployment to not install the `landscape-hashids` package, which means the hash-id database will not be set up. This should not be used for production deployments.
+Setting `min_install = "true"` configures the deployment to not install the `landscape-hashids` package, which means the hash-id database will not be set up, resulting in slower package reporting. This should not be used for production deployments.
 ```
 
 ### Deploying against legacy (pre-26.04) topologies
@@ -85,7 +85,7 @@ Setting `min_install = "true"` cofigures the deployment to not install the `land
 This module is version-aware: it doesn't take a "mode" variable. Instead, once `landscape_server` is deployed, the module inspects the relation interfaces that revision actually supports (its `database`, `has_modern_haproxy_interface`, and `inbound_amqp`/`outbound_amqp` requires) and wires the matching integrations automatically. The same module works unmodified against a pre-26.04 `landscape_server.channel` revision (legacy `pgsql` database interface, `reverseproxy`/`website` HAProxy relation, single `amqp` relation); you don't need a different plan to support an older revision, just the matching `terraform.tfvars.example` file above.
 
 ```{note}
-Both the legacy `pgsql` database interface and the legacy `reverseproxy`/`website` HAProxy interface are still supported for backwards compatibility, but are deprecated. Support for both will be removed in Landscape 26.10. See {ref}`how-to-migrate-to-26-04-charm` to migrate to the modern interfaces.
+Both the legacy `pgsql` database interface and the legacy `reverseproxy`/`website` HAProxy interface are still available for backwards compatibility, but are deprecated. Support for both will be removed in Landscape 26.10. See {ref}`how-to-migrate-to-26-04-charm` to migrate to the modern interfaces.
 ```
 
 ### Alternative: vendoring the module into your own Terraform plan
@@ -206,7 +206,9 @@ This module can be configured for high availability by configuring the `units` v
 ```hcl
 landscape_server = {
   units = 3
-  min_install = "false"
+  config = {
+    min_install = "false"
+  }
 }
 
 postgresql = {

--- a/docs/how-to-guides/landscape-installation-and-set-up/terraform-juju-deployment.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/terraform-juju-deployment.md
@@ -84,6 +84,10 @@ Setting `min_install = "true"` cofigures the deployment to not install the `land
 
 This module is version-aware: it doesn't take a "mode" variable. Instead, once `landscape_server` is deployed, the module inspects the relation interfaces that revision actually supports (its `database`, `has_modern_haproxy_interface`, and `inbound_amqp`/`outbound_amqp` requires) and wires the matching integrations automatically. The same module works unmodified against a pre-26.04 `landscape_server.channel` revision (legacy `pgsql` database interface, `reverseproxy`/`website` HAProxy relation, single `amqp` relation); you don't need a different plan to support an older revision, just the matching `terraform.tfvars.example` file above.
 
+```{note}
+Both the legacy `pgsql` database interface and the legacy `reverseproxy`/`website` HAProxy interface are still supported for backwards compatibility, but are deprecated. Support for both will be removed in Landscape 26.10. See {ref}`how-to-migrate-to-26-04-charm` to migrate to the modern interfaces.
+```
+
 ### Alternative: vendoring the module into your own Terraform plan
 
 If you're integrating Landscape into a larger, existing Terraform plan instead of deploying it standalone, reference the module by its Git source from your own configuration (for example, in a `main.tf` you create):

--- a/docs/how-to-guides/landscape-installation-and-set-up/terraform-juju-deployment.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/terraform-juju-deployment.md
@@ -76,6 +76,10 @@ cp terraform.tfvars.modern terraform.tfvars   # or terraform.tfvars.example for 
 
 Open `terraform.tfvars` and adjust it for your deployment, at minimum setting `landscape_server.config.root_url` to your own domain name. `landscape_debarchive` and `landscape_task_handler` are both required and should not be set to `null`; when set, the module automatically integrates both with `landscape_server`, `postgresql`, `tls_certificates`, and, for the task handler's gRPC route, `haproxy`.
 
+```{warning}
+Setting `min_install = "true"` cofigures the deployment to not install the `landscape-hashids` package, which means the hash-id database will not be set up. This should not be used for production deployments.
+```
+
 ### Deploying against legacy (pre-26.04) topologies
 
 This module is version-aware: it doesn't take a "mode" variable. Instead, once `landscape_server` is deployed, the module inspects the relation interfaces that revision actually supports (its `database`, `has_modern_haproxy_interface`, and `inbound_amqp`/`outbound_amqp` requires) and wires the matching integrations automatically. The same module works unmodified against a pre-26.04 `landscape_server.channel` revision (legacy `pgsql` database interface, `reverseproxy`/`website` HAProxy relation, single `amqp` relation); you don't need a different plan to support an older revision, just the matching `terraform.tfvars.example` file above.
@@ -175,14 +179,18 @@ HAProxy routes traffic based on the `hostname` configured in `landscape_server.c
 The same hostname resolution requirement applies internally: the outbox component on the `landscape_server` units connects to the Task Handler's gRPC server through HAProxy's `haproxy-route-tcp` passthrough, using the same hostname. If it doesn't resolve on the `landscape_server` units (for example, deploying locally without a real domain), add an `/etc/hosts` entry on those units pointing the hostname at the HAProxy unit's IP address. This dependency is one-directional: outbox (on `landscape_server`) connects to Task Handler, not the other way around.
 ```
 
-## Get the initial credentials and finish setup
+## Get the initial credentials and finish setup (optional)
 
-The module's outputs include `admin_email` and `admin_password` (sensitive) for the initial Landscape administrator account, and `registration_key` for registering clients. Retrieve them with:
+If provided as variables at apply time, the module's outputs include `admin_email` and `admin_password` (sensitive) for the initial Landscape administrator account, and `registration_key` for registering clients. Retrieve them with:
 
 ```sh
 terraform output admin_email
 terraform output admin_password
 terraform output registration_key
+```
+
+```{note}
+These commands will fail if these values were not set when the plan was applied.
 ```
 
 The outputs also include `applications` (the deployed charms and their integration endpoints), `has_modern_amqp_relations`, and `has_modern_postgres_interface`. See the {ref}`reference page <reference-landscape-product-modules-landscape-scalable>` for the full list.
@@ -194,6 +202,7 @@ This module can be configured for high availability by configuring the `units` v
 ```hcl
 landscape_server = {
   units = 3
+  min_install = "false"
 }
 
 postgresql = {
@@ -235,7 +244,7 @@ haproxy_route_tcp_offer_url = "<model-owner>/<offering-model>.<tcp-offer-name>"
 
 ## Using PgBouncer as a connection pooler
 
-For improved database performance and scalability in high-load deployments, set the `pgbouncer` input to deploy [PgBouncer](https://charmhub.io/pgbouncer) as a subordinate charm between Landscape Server and PostgreSQL. This requires a Landscape Server revision that supports the modern `database` interface (rather than the legacy `pgsql`/`db` endpoint):
+For improved database performance and scalability in high-load deployments, set the `pgbouncer` input to deploy [PgBouncer](https://charmhub.io/pgbouncer) as a subordinate charm between Landscape Server and PostgreSQL. This requires a Landscape Server revision that supports the modern `postgresql_client` interface (rather than the legacy `pgsql` interface):
 
 ```hcl
 pgbouncer = {
@@ -243,6 +252,10 @@ pgbouncer = {
     pool_mode = "transaction"
   }
 }
+```
+
+```{tip}
+Set the PgBouncer charm's [`max_db_connections`](https://charmhub.io/pgbouncer/configurations#max_db_connections) charm config option to control how many connections Landscape Server can use at a time.
 ```
 
 If you're also deploying PostgreSQL through this module's `postgresql` input, the module automatically integrates PgBouncer's `backend-database` endpoint with it. If instead you're using an external PostgreSQL deployment (`postgresql = null`), you need to create that integration yourself, connecting PgBouncer's `backend-database` endpoint to your PostgreSQL application's `database` endpoint (the application name is `"postgresql"` by default; override it below if you deployed it under a different name):

--- a/docs/how-to-guides/upgrade/migrate-to-26-04-charm.md
+++ b/docs/how-to-guides/upgrade/migrate-to-26-04-charm.md
@@ -44,6 +44,10 @@ Remove the older HAProxy relation:
 juju remove-relation landscape-server:website haproxy:reverseproxy
 ```
 
+```{note}
+The legacy `website` relation (`reverseproxy` interface) is still supported for backwards compatibility, but is deprecated. Support will be removed in Landscape 26.10, so it is recommended to complete this migration to the `haproxy-route` interface rather than continuing to rely on the legacy relation.
+```
+
 **For deployments older than 25.10 only:**
 
 Remove the older RabbitMQ relation:
@@ -234,7 +238,7 @@ If you want to upgrade to a newer PostgreSQL version (e.g., from 14 to 16) as pa
 ```{note}
 PostgreSQL upgrade is optional. The 26.04 charm uses the modern `postgresql_client` interface which works with PostgreSQL 14 and above.
 
-The legacy `db` endpoint (legacy `pgsql` interface) is still supported for backwards compatibility but only works with PostgreSQL 14. It is recommended to migrate to the modern `postgresql_client` interface since Charmed PostgreSQL 16+ does not support the legacy interface.
+The legacy `db` endpoint (legacy `pgsql` interface) is still supported for backwards compatibility but only works with PostgreSQL 14, and is deprecated: support will be removed in Landscape 26.10. It is recommended to migrate to the modern `postgresql_client` interface since Charmed PostgreSQL 16+ does not support the legacy interface.
 ```
 
 ### Step 8: Verify the deployment

--- a/docs/how-to-guides/upgrade/migrate-to-26-04-charm.md
+++ b/docs/how-to-guides/upgrade/migrate-to-26-04-charm.md
@@ -22,7 +22,7 @@ The 26.04 version introduces significant architectural changes:
 | Aspect                   | Landscape 26.04 LTS                                                                         | Pre-26.04                                                    |
 | ------------------------ | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
 | **Load balancing**       | External HAProxy charm (`haproxy` at `2.8/stable`, `haproxy-route` interface)                     | External HAProxy charm (`reverseproxy` interface)            |
-| **PostgreSQL interface** | Modern `database` interface (PostgreSQL 14+)                                                      | Legacy `pgsql` interface (PostgreSQL 14)                     |
+| **PostgreSQL interface** | Modern `postgresql_client` interface (PostgreSQL 14+)                                                      | Legacy `pgsql` interface (PostgreSQL 14)                     |
 | **PostgreSQL relation**  | `landscape-server:database` → `postgresql:database`                                               | `landscape-server:db` → `postgresql:db-admin`                |
 | **RabbitMQ relation**    | `landscape-server:inbound-amqp` and `landscape-server:outbound-amqp` → `rabbitmq-server` (25.10+) | `landscape-server:amqp` → `rabbitmq-server:amqp` (pre-25.10) |
 | **HAProxy relation**     | `landscape-server:*-haproxy-route` → `haproxy:haproxy-route` (8 route endpoints)                  | `landscape-server:website` → `haproxy:reverseproxy`          |
@@ -232,9 +232,9 @@ juju integrate landscape-server:outbound-amqp rabbitmq-server
 If you want to upgrade to a newer PostgreSQL version (e.g., from 14 to 16) as part of this migration, follow the backup and restore procedures in {ref}`how-to-back-up-restore-tear-down-charmed-deployment` to migrate your data to a new PostgreSQL deployment.
 
 ```{note}
-PostgreSQL upgrade is optional. The 26.04 charm uses the modern `database` interface which works with PostgreSQL 14 and above.
+PostgreSQL upgrade is optional. The 26.04 charm uses the modern `postgresql_client` interface which works with PostgreSQL 14 and above.
 
-The legacy `db` endpoint (legacy `pgsql` interface) is still supported for backwards compatibility but only works with PostgreSQL 14. It is recommended to migrate to the modern `database` interface since Charmed PostgreSQL 16+ does not support the legacy interface.
+The legacy `db` endpoint (legacy `pgsql` interface) is still supported for backwards compatibility but only works with PostgreSQL 14. It is recommended to migrate to the modern `postgresql_client` interface since Charmed PostgreSQL 16+ does not support the legacy interface.
 ```
 
 ### Step 8: Verify the deployment

--- a/docs/how-to-guides/upgrade/migrate-to-26-04-charm.md
+++ b/docs/how-to-guides/upgrade/migrate-to-26-04-charm.md
@@ -45,7 +45,7 @@ juju remove-relation landscape-server:website haproxy:reverseproxy
 ```
 
 ```{note}
-The legacy `website` relation (`reverseproxy` interface) is still supported for backwards compatibility, but is deprecated. Support will be removed in Landscape 26.10, so it is recommended to complete this migration to the `haproxy-route` interface rather than continuing to rely on the legacy relation.
+The legacy `website` relation (`reverseproxy` interface) is still available for backwards compatibility, but is deprecated. Support will be removed in Landscape 26.10, so it is recommended to complete this migration to the `haproxy-route` interface rather than continuing to rely on the legacy relation.
 ```
 
 **For deployments older than 25.10 only:**


### PR DESCRIPTION
I also chose 26.10 as the deprecation date for legacy PG/HAproxy rels