### PR TITLE
fix: update landscape-debarchive installation to stable channel

### DIFF
--- a/docs/how-to-guides/landscape-installation-and-set-up/debarchive-repository-management.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/debarchive-repository-management.md
@@ -37,7 +37,7 @@ Install the snap on the same machine as the Landscape application server.
 - For Manual installations, this is the Landscape application server.
 
 ```bash
-sudo snap install landscape-debarchive --channel=latest/beta
+sudo snap install landscape-debarchive --channel=latest/stable
 ```
 
 The snap installs as a daemon that will start automatically. It will fail to connect to the database until the remaining configuration steps are completed.


### PR DESCRIPTION
Updated installation command to use the stable channel for landscape-debarchive.