### PR TITLE
fix(ci): open the sync PR from a branch and merge it when clean

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -5,6 +5,17 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      source_branch:
+        description: "Branch to sync from. Override only to test the workflow."
+        required: false
+        default: main
+        type: string
+      target_branch:
+        description: "Branch to sync into. Override only to test the workflow."
+        required: false
+        default: develop
+        type: string
 
 concurrency:
   group: sync-main-to-develop
@@ -18,20 +29,30 @@ jobs:
 
     env:
       GH_TOKEN: ${{ secrets.LANDSCAPE_SYNC_TOKEN }}
-      SYNC_BRANCH: sync-main-into-develop
 
     steps:
-      - name: Check whether develop is already up to date
+      - name: Resolve the branches to sync
+        run: |
+          source_branch="${{ inputs.source_branch || 'main' }}"
+          target_branch="${{ inputs.target_branch || 'develop' }}"
+          {
+            echo "SOURCE_BRANCH=${source_branch}"
+            echo "TARGET_BRANCH=${target_branch}"
+            echo "SYNC_BRANCH=sync-${source_branch//\//-}-into-${target_branch//\//-}"
+          } >> "$GITHUB_ENV"
+          echo "Syncing ${source_branch} into ${target_branch}."
+
+      - name: Check whether the target branch is already up to date
         id: compare
         run: |
           ahead_by=$(gh api \
-            "repos/${{ github.repository }}/compare/develop...main" \
+            "repos/${{ github.repository }}/compare/${TARGET_BRANCH}...${SOURCE_BRANCH}" \
             --jq '.ahead_by')
           echo "ahead_by=${ahead_by}" >> "$GITHUB_OUTPUT"
           if [ "${ahead_by}" = "0" ]; then
-            echo "develop is already up to date with main – no sync needed."
+            echo "${TARGET_BRANCH} is already up to date with ${SOURCE_BRANCH} – no sync needed."
           else
-            echo "main is ${ahead_by} commit(s) ahead of develop – sync required."
+            echo "${SOURCE_BRANCH} is ${ahead_by} commit(s) ahead of ${TARGET_BRANCH} – sync required."
           fi
 
       - name: Check out the repository
@@ -41,8 +62,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.LANDSCAPE_SYNC_TOKEN }}
 
-      # The PR head must be a throwaway branch, not main itself. If the PR head
-      # is main, conflicts can only be resolved by committing develop into main.
+      # The PR head must be a throwaway branch, not the source branch itself.
+      # If the PR head is main, conflicts can only be resolved by committing
+      # develop into main.
       - name: Update the sync branch
         if: steps.compare.outputs.ahead_by != '0'
         id: branch
@@ -52,7 +74,7 @@ jobs:
 
           existing_pr=$(gh pr list \
             --repo "${{ github.repository }}" \
-            --base develop \
+            --base "${TARGET_BRANCH}" \
             --head "${SYNC_BRANCH}" \
             --state open \
             --json number \
@@ -60,18 +82,18 @@ jobs:
 
           if [ -n "${existing_pr}" ]; then
             # The branch may carry manual conflict resolutions, so advance it
-            # instead of resetting it onto main.
+            # instead of resetting it onto the source branch.
             echo "Reusing sync branch behind open PR #${existing_pr}."
             git checkout -B "${SYNC_BRANCH}" "origin/${SYNC_BRANCH}"
-            if git merge --no-edit origin/main; then
+            if git merge --no-edit "origin/${SOURCE_BRANCH}"; then
               git push origin "${SYNC_BRANCH}"
             else
               git merge --abort
-              echo "::warning::main does not merge cleanly into ${SYNC_BRANCH}. Resolve the conflicts on PR #${existing_pr}."
+              echo "::warning::${SOURCE_BRANCH} does not merge cleanly into ${SYNC_BRANCH}. Resolve the conflicts on PR #${existing_pr}."
               echo "blocked=true" >> "$GITHUB_OUTPUT"
             fi
           else
-            git checkout -B "${SYNC_BRANCH}" origin/main
+            git checkout -B "${SYNC_BRANCH}" "origin/${SOURCE_BRANCH}"
             git push --force-with-lease origin "${SYNC_BRANCH}"
           fi
 
@@ -86,10 +108,10 @@ jobs:
           if [ -z "${pr_number}" ]; then
             pr_url=$(gh pr create \
               --repo "${{ github.repository }}" \
-              --base develop \
+              --base "${TARGET_BRANCH}" \
               --head "${SYNC_BRANCH}" \
-              --title "merge: sync main into develop" \
-              --body "Automated sync of main into develop. Triggered by commit ${{ github.sha }}.")
+              --title "merge: sync ${SOURCE_BRANCH} into ${TARGET_BRANCH}" \
+              --body "Automated sync of ${SOURCE_BRANCH} into ${TARGET_BRANCH}. Triggered by commit ${{ github.sha }}.")
             pr_number=$(echo "${pr_url}" | grep -oE '[0-9]+$')
             echo "Created PR #${pr_number}: ${pr_url}"
           else
@@ -124,7 +146,7 @@ jobs:
           fi
 
           if gh pr merge --merge "${pr_number}" \
-            --subject "auto: sync main into develop" \
+            --subject "auto: sync ${SOURCE_BRANCH} into ${TARGET_BRANCH}" \
             --delete-branch \
             --repo "${{ github.repository }}"; then
             echo "Merged PR #${pr_number}."
@@ -133,7 +155,7 @@ jobs:
 
           # Required checks or reviews can block an immediate merge; queue it instead.
           output=$(gh pr merge --auto --merge "${pr_number}" \
-            --subject "auto: sync main into develop" \
+            --subject "auto: sync ${SOURCE_BRANCH} into ${TARGET_BRANCH}" \
             --delete-branch \
             --repo "${{ github.repository }}" 2>&1) && rc=0 || rc=$?
           if [ "${rc}" -eq 0 ]; then

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Check out the repository
         if: steps.compare.outputs.ahead_by != '0'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.LANDSCAPE_SYNC_TOKEN }}

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -5,17 +5,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      source_branch:
-        description: "Branch to sync from. Override only to test the workflow."
-        required: false
-        default: main
-        type: string
-      target_branch:
-        description: "Branch to sync into. Override only to test the workflow."
-        required: false
-        default: develop
-        type: string
 
 concurrency:
   group: sync-main-to-develop
@@ -29,30 +18,20 @@ jobs:
 
     env:
       GH_TOKEN: ${{ secrets.LANDSCAPE_SYNC_TOKEN }}
+      SYNC_BRANCH: sync-main-into-develop
 
     steps:
-      - name: Resolve the branches to sync
-        run: |
-          source_branch="${{ inputs.source_branch || 'main' }}"
-          target_branch="${{ inputs.target_branch || 'develop' }}"
-          {
-            echo "SOURCE_BRANCH=${source_branch}"
-            echo "TARGET_BRANCH=${target_branch}"
-            echo "SYNC_BRANCH=sync-${source_branch//\//-}-into-${target_branch//\//-}"
-          } >> "$GITHUB_ENV"
-          echo "Syncing ${source_branch} into ${target_branch}."
-
-      - name: Check whether the target branch is already up to date
+      - name: Check whether develop is already up to date
         id: compare
         run: |
           ahead_by=$(gh api \
-            "repos/${{ github.repository }}/compare/${TARGET_BRANCH}...${SOURCE_BRANCH}" \
+            "repos/${{ github.repository }}/compare/develop...main" \
             --jq '.ahead_by')
           echo "ahead_by=${ahead_by}" >> "$GITHUB_OUTPUT"
           if [ "${ahead_by}" = "0" ]; then
-            echo "${TARGET_BRANCH} is already up to date with ${SOURCE_BRANCH} – no sync needed."
+            echo "develop is already up to date with main – no sync needed."
           else
-            echo "${SOURCE_BRANCH} is ${ahead_by} commit(s) ahead of ${TARGET_BRANCH} – sync required."
+            echo "main is ${ahead_by} commit(s) ahead of develop – sync required."
           fi
 
       - name: Check out the repository
@@ -62,9 +41,8 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.LANDSCAPE_SYNC_TOKEN }}
 
-      # The PR head must be a throwaway branch, not the source branch itself.
-      # If the PR head is main, conflicts can only be resolved by committing
-      # develop into main.
+      # The PR head must be a throwaway branch, not main itself. If the PR head
+      # is main, conflicts can only be resolved by committing develop into main.
       - name: Update the sync branch
         if: steps.compare.outputs.ahead_by != '0'
         id: branch
@@ -74,7 +52,7 @@ jobs:
 
           existing_pr=$(gh pr list \
             --repo "${{ github.repository }}" \
-            --base "${TARGET_BRANCH}" \
+            --base develop \
             --head "${SYNC_BRANCH}" \
             --state open \
             --json number \
@@ -82,18 +60,18 @@ jobs:
 
           if [ -n "${existing_pr}" ]; then
             # The branch may carry manual conflict resolutions, so advance it
-            # instead of resetting it onto the source branch.
+            # instead of resetting it onto main.
             echo "Reusing sync branch behind open PR #${existing_pr}."
             git checkout -B "${SYNC_BRANCH}" "origin/${SYNC_BRANCH}"
-            if git merge --no-edit "origin/${SOURCE_BRANCH}"; then
+            if git merge --no-edit origin/main; then
               git push origin "${SYNC_BRANCH}"
             else
               git merge --abort
-              echo "::warning::${SOURCE_BRANCH} does not merge cleanly into ${SYNC_BRANCH}. Resolve the conflicts on PR #${existing_pr}."
+              echo "::warning::main does not merge cleanly into ${SYNC_BRANCH}. Resolve the conflicts on PR #${existing_pr}."
               echo "blocked=true" >> "$GITHUB_OUTPUT"
             fi
           else
-            git checkout -B "${SYNC_BRANCH}" "origin/${SOURCE_BRANCH}"
+            git checkout -B "${SYNC_BRANCH}" origin/main
             git push --force-with-lease origin "${SYNC_BRANCH}"
           fi
 
@@ -108,10 +86,10 @@ jobs:
           if [ -z "${pr_number}" ]; then
             pr_url=$(gh pr create \
               --repo "${{ github.repository }}" \
-              --base "${TARGET_BRANCH}" \
+              --base develop \
               --head "${SYNC_BRANCH}" \
-              --title "merge: sync ${SOURCE_BRANCH} into ${TARGET_BRANCH}" \
-              --body "Automated sync of ${SOURCE_BRANCH} into ${TARGET_BRANCH}. Triggered by commit ${{ github.sha }}.")
+              --title "merge: sync main into develop" \
+              --body "Automated sync of main into develop. Triggered by commit ${{ github.sha }}.")
             pr_number=$(echo "${pr_url}" | grep -oE '[0-9]+$')
             echo "Created PR #${pr_number}: ${pr_url}"
           else
@@ -146,7 +124,7 @@ jobs:
           fi
 
           if gh pr merge --merge "${pr_number}" \
-            --subject "auto: sync ${SOURCE_BRANCH} into ${TARGET_BRANCH}" \
+            --subject "auto: sync main into develop" \
             --delete-branch \
             --repo "${{ github.repository }}"; then
             echo "Merged PR #${pr_number}."
@@ -155,7 +133,7 @@ jobs:
 
           # Required checks or reviews can block an immediate merge; queue it instead.
           output=$(gh pr merge --auto --merge "${pr_number}" \
-            --subject "auto: sync ${SOURCE_BRANCH} into ${TARGET_BRANCH}" \
+            --subject "auto: sync main into develop" \
             --delete-branch \
             --repo "${{ github.repository }}" 2>&1) && rc=0 || rc=$?
           if [ "${rc}" -eq 0 ]; then

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -18,6 +18,7 @@ jobs:
 
     env:
       GH_TOKEN: ${{ secrets.LANDSCAPE_SYNC_TOKEN }}
+      SYNC_BRANCH: sync-main-into-develop
 
     steps:
       - name: Check whether develop is already up to date
@@ -33,51 +34,110 @@ jobs:
             echo "main is ${ahead_by} commit(s) ahead of develop – sync required."
           fi
 
-      - name: Create or reuse sync PR
+      - name: Check out the repository
         if: steps.compare.outputs.ahead_by != '0'
-        id: ensure-pr
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.LANDSCAPE_SYNC_TOKEN }}
+
+      # The PR head must be a throwaway branch, not main itself. If the PR head
+      # is main, conflicts can only be resolved by committing develop into main.
+      - name: Update the sync branch
+        if: steps.compare.outputs.ahead_by != '0'
+        id: branch
         run: |
-          pr_number=$(gh pr list \
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          existing_pr=$(gh pr list \
             --repo "${{ github.repository }}" \
             --base develop \
-            --head main \
+            --head "${SYNC_BRANCH}" \
             --state open \
             --json number \
             --jq '.[0].number // ""')
 
-          if [ -n "${pr_number}" ]; then
-            echo "Reusing existing open PR #${pr_number}."
+          if [ -n "${existing_pr}" ]; then
+            # The branch may carry manual conflict resolutions, so advance it
+            # instead of resetting it onto main.
+            echo "Reusing sync branch behind open PR #${existing_pr}."
+            git checkout -B "${SYNC_BRANCH}" "origin/${SYNC_BRANCH}"
+            if git merge --no-edit origin/main; then
+              git push origin "${SYNC_BRANCH}"
+            else
+              git merge --abort
+              echo "::warning::main does not merge cleanly into ${SYNC_BRANCH}. Resolve the conflicts on PR #${existing_pr}."
+              echo "blocked=true" >> "$GITHUB_OUTPUT"
+            fi
           else
+            git checkout -B "${SYNC_BRANCH}" origin/main
+            git push --force-with-lease origin "${SYNC_BRANCH}"
+          fi
+
+          echo "pr_number=${existing_pr}" >> "$GITHUB_OUTPUT"
+
+      - name: Create or reuse sync PR
+        if: steps.compare.outputs.ahead_by != '0' && steps.branch.outputs.blocked != 'true'
+        id: ensure-pr
+        run: |
+          pr_number="${{ steps.branch.outputs.pr_number }}"
+
+          if [ -z "${pr_number}" ]; then
             pr_url=$(gh pr create \
               --repo "${{ github.repository }}" \
               --base develop \
-              --head main \
+              --head "${SYNC_BRANCH}" \
               --title "merge: sync main into develop" \
               --body "Automated sync of main into develop. Triggered by commit ${{ github.sha }}.")
             pr_number=$(echo "${pr_url}" | grep -oE '[0-9]+$')
             echo "Created PR #${pr_number}: ${pr_url}"
+          else
+            echo "Reusing existing open PR #${pr_number}."
           fi
 
           echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
 
-      - name: Enable auto-merge on the sync PR
+      - name: Merge the sync PR
         if: steps.compare.outputs.ahead_by != '0' && steps.ensure-pr.outputs.pr_number != ''
         run: |
           pr_number="${{ steps.ensure-pr.outputs.pr_number }}"
-          already_set=$(gh pr view "${pr_number}" \
-            --repo "${{ github.repository }}" \
-            --json autoMergeRequest \
-            --jq '.autoMergeRequest != null')
 
-          if [ "${already_set}" = "true" ]; then
-            echo "Auto-merge already enabled on PR #${pr_number}."
+          # GitHub computes mergeability asynchronously and reports UNKNOWN until it finishes.
+          mergeable=UNKNOWN
+          for _ in $(seq 1 12); do
+            mergeable=$(gh pr view "${pr_number}" \
+              --repo "${{ github.repository }}" \
+              --json mergeable --jq '.mergeable')
+            [ "${mergeable}" = "UNKNOWN" ] || break
+            sleep 5
+          done
+
+          if [ "${mergeable}" = "CONFLICTING" ]; then
+            echo "::warning::PR #${pr_number} has conflicts. Resolve them on the ${SYNC_BRANCH} branch, then re-run this workflow."
+            exit 0
+          fi
+
+          if [ "${mergeable}" != "MERGEABLE" ]; then
+            echo "::warning::PR #${pr_number} is not mergeable (state: ${mergeable})."
+            exit 0
+          fi
+
+          if gh pr merge --merge "${pr_number}" \
+            --subject "auto: sync main into develop" \
+            --delete-branch \
+            --repo "${{ github.repository }}"; then
+            echo "Merged PR #${pr_number}."
+            exit 0
+          fi
+
+          # Required checks or reviews can block an immediate merge; queue it instead.
+          output=$(gh pr merge --auto --merge "${pr_number}" \
+            --subject "auto: sync main into develop" \
+            --delete-branch \
+            --repo "${{ github.repository }}" 2>&1) && rc=0 || rc=$?
+          if [ "${rc}" -eq 0 ]; then
+            echo "Immediate merge was blocked; auto-merge enabled on PR #${pr_number}."
           else
-            output=$(gh pr merge --auto --merge "${pr_number}" \
-              --subject "auto: sync main into develop" \
-              --repo "${{ github.repository }}" 2>&1) && rc=0 || rc=$?
-            if [ "${rc}" -eq 0 ]; then
-              echo "Auto-merge (merge commit) enabled on PR #${pr_number}."
-            else
-              echo "::warning::Could not enable auto-merge on PR #${pr_number}: ${output}"
-            fi
+            echo "::warning::Could not merge PR #${pr_number}: ${output}"
           fi


### PR DESCRIPTION
The sync PR used main as its head branch, so conflicts could only be resolved by committing develop into main, which would pull unreleased docs onto main. Open the PR from a disposable sync-main-into-develop branch instead, so conflicts can be resolved on the PR itself.

Also merge the PR outright when GitHub reports it as mergeable, falling back to auto-merge only when required checks or reviews block it.

Tested that it works [here](https://github.com/canonical/landscape-documentation/actions/runs/33908206918/job/101138114151)