### PR TITLE
fix: change rule to avoid double backslash in replacement

### DIFF
--- a/docs/how-to-guides/landscape-installation-and-set-up/debarchive-repository-management.md
+++ b/docs/how-to-guides/landscape-installation-and-set-up/debarchive-repository-management.md
@@ -290,7 +290,7 @@ Add a new backend section:
 
 ```text
 backend debarchive
-    http-request set-path %[path,regsub(^/debarchive,/)]
+    http-request replace-path ^/debarchive/(.*) /\1
     server debarchive 127.0.0.1:8100 check
 ```
 


### PR DESCRIPTION
There's a problem where the existing config replaces `/debarchive` with `/` which leads to something like `fqdn/debarchive/v1` being translated to `fqdn//v1` which has a problematic `//`.

Here are haproxy logs from a development setup with the 404 associated with the old rule and the 200 associated with the new rule.

```
Sep 08 21:28:47 landscape-server-noble haproxy[289604]: 10.38.167.231:39356 [08/Sep/2026:21:28:47.786] haproxy-0-443~ debarchive/debarchive 0/0/0/0/0 404 163 - - ---- 2/2/0/0/0 0/0 "GET https://landscape-server-noble/debarchive/v1/mirrors HTTP/2.0"
Sep 08 21:38:40 landscape-server-noble haproxy[315560]: 10.38.167.1:32828 [08/Sep/2026:21:38:40.342] haproxy-0-443~ debarchive/debarchive 0/0/3/101/104 200 333 - - ---- 1/1/0/0/0 0/0 "GET https://landscape-server-noble/debarchive/v1/mirrors?pageSize=1000 HTTP/2.0"
```